### PR TITLE
Add a new module for creating Redash ECS cluster

### DIFF
--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -1,0 +1,90 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Create Redash ECS cluster and its Application load balancer.
+
+### Prerequisite
+
+N/A
+
+### Usage
+
+```hcl
+module "redash" {
+  source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v1.4.0"
+
+  container_image_url = "redash/redash:8.0.2.b37747"
+
+  container_environments = [
+    {
+      name   = "(Environment variable name)"
+      value  = "(plain string)"
+    },
+  ]
+
+  container_secrets = [
+    {
+      name   = "(Secret environment variable name)"
+      value  = aws_ssm_parameter.xxx.name
+    },
+  ]
+
+  ecs_security_group_ids = ["sg-aaa", "sg-bbb"]
+  ecs_subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+  ecs_task_role_arn      = "arn:aws:iam:xyz"
+  lb_access_log_bucket   = "S3 bucket name"
+  lb_certificate_arn     = "arn:aws:acm:xyz"
+  lb_security_groups     = ["sg-ccc", "sg-ddd"]
+  lb_subnets             = ["subnet-ccc", "subnet-ddd"]
+  prefix                 = "any string"
+  vpc_id                 = "vpc-xxx"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cloudwatch\_logs\_retention\_in\_days | The number of days you want to retain log events | `number` | `90` | no |
+| container\_environments | The environments to set to each ECS container | `list` | n/a | yes |
+| container\_image\_url | The URL of the image used to launch the container. Images in the Docker Hub registry available by default | `string` | n/a | yes |
+| container\_secrets | The secrets to set to each ECS container | `list` | n/a | yes |
+| db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
+| db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
+| ecs\_security\_group\_ids | The list of security group IDs to assign to the ECS task or service | `list` | n/a | yes |
+| ecs\_subnet\_ids | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
+| ecs\_task\_role\_arn | The ARN of the task execution role | `string` | n/a | yes |
+| lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
+| lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
+| lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |
+| lb\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| lb\_subnets | The list of subnet IDs to attach to the LB | `list` | n/a | yes |
+| prefix | A prefix for the resource names | `string` | `""` | no |
+| server\_container\_cpu | The number of cpu units to reserve for the server container | `number` | `1024` | no |
+| server\_container\_memory | The amount of memory (in MiB) to allow the server container | `number` | `2048` | no |
+| server\_desired\_count | The number of redash server tasks | `number` | `1` | no |
+| vpc\_id | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
+| worker\_container\_cpu | The number of cpu units to reserve for the worker container | `number` | `1024` | no |
+| worker\_container\_memory | The amount of memory (in MiB) to allow the worker container | `number` | `2048` | no |
+| worker\_desired\_count | The number of redash worker tasks | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| lb\_dns | The DNS name of LB |
+| lb\_zone\_id | The Zone ID of LB |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -69,6 +69,7 @@ module "redash" {
 | ecs\_subnet\_ids | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_task\_role\_arn | The ARN of the ECS task role | `string` | n/a | yes |
 | lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
+| lb\_access\_log\_prefix | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
 | lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
 | lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |
 | lb\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -29,6 +29,7 @@ module "redash" {
     },
   ]
 
+  ecs_execution_role_arn = "arn:aws:iam:abc"
   ecs_security_group_ids = ["sg-aaa", "sg-bbb"]
   ecs_subnet_ids         = ["subnet-aaa", "subnet-bbb"]
   ecs_task_role_arn      = "arn:aws:iam:xyz"
@@ -63,9 +64,10 @@ module "redash" {
 | container\_secrets | The secrets to set to each ECS container | `list` | n/a | yes |
 | db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
 | db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
+| ecs\_execution\_role\_arn | The ARN of ECS execution role | `string` | n/a | yes |
 | ecs\_security\_group\_ids | The list of security group IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_subnet\_ids | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
-| ecs\_task\_role\_arn | The ARN of the task execution role | `string` | n/a | yes |
+| ecs\_task\_role\_arn | The ARN of the ECS task role | `string` | n/a | yes |
 | lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
 | lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
 | lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -24,8 +24,8 @@ module "redash" {
 
   container_secrets = [
     {
-      name   = "(Secret environment variable name)"
-      value  = aws_ssm_parameter.xxx.name
+      name      = "(Secret environment variable name)"
+      valueFrom = aws_ssm_parameter.xxx.name
     },
   ]
 

--- a/aws/redash/cloudwatch_logs.tf
+++ b/aws/redash/cloudwatch_logs.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_log_group" "logs" {
+  for_each = local.container_names
+
+  name              = each.value
+  retention_in_days = var.cloudwatch_logs_retention_in_days
+}

--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -50,6 +50,31 @@ module "worker_container_definition" {
   }
 }
 
+# DB Create
+module "db_create_container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.37.0"
+
+  container_name   = local.container_names["db_create"]
+  container_image  = var.container_image_url
+  container_cpu    = var.db_container_cpu
+  container_memory = var.db_container_memory
+  command          = local.commands["db_create"]
+  environment      = []
+  secrets          = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["db_create"].name
+      "awslogs-stream-prefix" = "db-create"
+    }
+  }
+}
+
 # DB Migrate
 module "db_migrate_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"

--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -1,0 +1,101 @@
+# Server
+module "server_container_definitions" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.37.0"
+
+  container_name   = local.container_names["server"]
+  container_image  = var.container_image_url
+  container_cpu    = var.server_container_cpu
+  container_memory = var.server_container_memory
+
+  command       = local.commands["server"]
+  port_mappings = local.port_mappings
+  environment   = var.container_environments
+  secrets       = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["server"].name
+      "awslogs-stream-prefix" = "server"
+    }
+  }
+}
+
+# Worker
+module "worker_container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.37.0"
+
+  container_name   = local.container_names["worker"]
+  container_image  = var.container_image_url
+  container_cpu    = var.worker_container_cpu
+  container_memory = var.worker_container_memory
+  command          = local.commands["worker"]
+  environment      = var.container_environments
+  secrets          = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["worker"].name
+      "awslogs-stream-prefix" = "worker"
+    }
+  }
+}
+
+# DB Migrate
+module "db_migrate_container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.37.0"
+
+  container_name   = local.container_names["db_migrate"]
+  container_image  = var.container_image_url
+  container_cpu    = var.db_container_cpu
+  container_memory = var.db_container_memory
+  command          = local.commands["db_migrate"]
+  environment      = []
+  secrets          = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["db_migrate"].name
+      "awslogs-stream-prefix" = "db-migrate"
+    }
+  }
+}
+
+# DB Upgrade
+module "db_upgrade_container_definition" {
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.37.0"
+
+  container_name   = local.container_names["db_upgrade"]
+  container_image  = var.container_image_url
+  container_cpu    = var.db_container_cpu
+  container_memory = var.db_container_memory
+  command          = local.commands["db_upgrade"]
+  environment      = []
+  secrets          = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["db_upgrade"].name
+      "awslogs-stream-prefix" = "db-upgrade"
+    }
+  }
+}

--- a/aws/redash/data.tf
+++ b/aws/redash/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -69,6 +69,18 @@ resource "aws_ecs_service" "worker" {
   }
 }
 
+## DB Create
+resource "aws_ecs_task_definition" "db_create" {
+  family                   = local.container_names["db_create"]
+  container_definitions    = module.db_create_container_definition.json
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.db_container_cpu
+  memory                   = var.db_container_memory
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+}
+
 ## DB Migrate
 resource "aws_ecs_task_definition" "db_migrate" {
   family                   = local.container_names["db_migrate"]

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -1,0 +1,90 @@
+# ECS Cluster
+resource "aws_ecs_cluster" "redash" {
+  name = local.base_name
+}
+
+## Server
+resource "aws_ecs_task_definition" "server" {
+  family                   = local.container_names["server"]
+  container_definitions    = module.server_container_definitions.json
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.server_container_cpu
+  memory                   = var.server_container_memory
+  execution_role_arn       = var.ecs_task_role_arn
+}
+
+resource "aws_ecs_service" "server" {
+  name                               = local.container_names["server"]
+  launch_type                        = "FARGATE"
+  cluster                            = aws_ecs_cluster.redash.id
+  task_definition                    = aws_ecs_task_definition.server.arn
+  desired_count                      = var.server_desired_count
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    security_groups  = var.ecs_security_group_ids
+    subnets          = var.ecs_subnet_ids
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.redash.arn
+    container_name   = local.container_names["server"]
+    container_port   = 5000
+  }
+
+  depends_on = [
+    aws_lb_listener.https,
+  ]
+}
+
+## Worker
+resource "aws_ecs_task_definition" "worker" {
+  family                   = local.container_names["worker"]
+  container_definitions    = module.worker_container_definition.json
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.worker_container_cpu
+  memory                   = var.worker_container_memory
+  execution_role_arn       = var.ecs_task_role_arn
+}
+
+resource "aws_ecs_service" "worker" {
+  name                               = local.container_names["worker"]
+  launch_type                        = "FARGATE"
+  cluster                            = aws_ecs_cluster.redash.id
+  task_definition                    = aws_ecs_task_definition.worker.arn
+  desired_count                      = var.worker_desired_count
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    security_groups  = var.ecs_security_group_ids
+    subnets          = var.ecs_subnet_ids
+    assign_public_ip = false
+  }
+}
+
+## DB Migrate
+resource "aws_ecs_task_definition" "db_migrate" {
+  family                   = local.container_names["db_migrate"]
+  container_definitions    = module.db_migrate_container_definition.json
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.db_container_cpu
+  memory                   = var.db_container_memory
+  execution_role_arn       = var.ecs_task_role_arn
+}
+
+## DB Upgrade
+resource "aws_ecs_task_definition" "db_upgrade" {
+  family                   = local.container_names["db_upgrade"]
+  container_definitions    = module.db_upgrade_container_definition.json
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.db_container_cpu
+  memory                   = var.db_container_memory
+  execution_role_arn       = var.ecs_task_role_arn
+}

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -11,7 +11,8 @@ resource "aws_ecs_task_definition" "server" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.server_container_cpu
   memory                   = var.server_container_memory
-  execution_role_arn       = var.ecs_task_role_arn
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
 }
 
 resource "aws_ecs_service" "server" {
@@ -48,7 +49,8 @@ resource "aws_ecs_task_definition" "worker" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.worker_container_cpu
   memory                   = var.worker_container_memory
-  execution_role_arn       = var.ecs_task_role_arn
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
 }
 
 resource "aws_ecs_service" "worker" {
@@ -75,7 +77,8 @@ resource "aws_ecs_task_definition" "db_migrate" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.db_container_cpu
   memory                   = var.db_container_memory
-  execution_role_arn       = var.ecs_task_role_arn
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
 }
 
 ## DB Upgrade
@@ -86,5 +89,6 @@ resource "aws_ecs_task_definition" "db_upgrade" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.db_container_cpu
   memory                   = var.db_container_memory
-  execution_role_arn       = var.ecs_task_role_arn
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
 }

--- a/aws/redash/lb.tf
+++ b/aws/redash/lb.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "redash" {
 
     content {
       bucket  = access_logs.value
-      prefix  = local.base_name
+      prefix  = var.lb_access_log_prefix ? var.lb_access_log_prefix : local.base_name
       enabled = true
     }
   }

--- a/aws/redash/lb.tf
+++ b/aws/redash/lb.tf
@@ -27,13 +27,13 @@ resource "aws_lb_target_group" "redash" {
   target_type          = "ip"
 
   health_check {
-    interval            = "30"
+    interval            = "10"
     path                = "/ping"
     port                = "traffic-port"
     protocol            = "HTTP"
     matcher             = "200"
-    timeout             = 5
-    healthy_threshold   = 5
+    timeout             = 3
+    healthy_threshold   = 3
     unhealthy_threshold = 2
   }
 }

--- a/aws/redash/lb.tf
+++ b/aws/redash/lb.tf
@@ -1,0 +1,68 @@
+# LB
+resource "aws_lb" "redash" {
+  name                       = local.base_name
+  internal                   = false
+  security_groups            = var.lb_security_groups
+  subnets                    = var.lb_subnets
+  enable_deletion_protection = true
+  ip_address_type            = "ipv4"
+
+  dynamic "access_logs" {
+    for_each = [var.lb_access_log_bucket]
+
+    content {
+      bucket  = access_logs.value
+      prefix  = local.base_name
+      enabled = true
+    }
+  }
+}
+
+resource "aws_lb_target_group" "redash" {
+  name                 = local.base_name
+  port                 = 5000
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 30
+  target_type          = "ip"
+
+  health_check {
+    interval            = "30"
+    path                = "/ping"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.redash.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.redash.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = var.lb_ssl_policy
+  certificate_arn   = var.lb_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.redash.arn
+  }
+}

--- a/aws/redash/lb.tf
+++ b/aws/redash/lb.tf
@@ -12,7 +12,7 @@ resource "aws_lb" "redash" {
 
     content {
       bucket  = access_logs.value
-      prefix  = var.lb_access_log_prefix ? var.lb_access_log_prefix : local.base_name
+      prefix  = var.lb_access_log_prefix == null ? local.base_name : var.lb_access_log_prefix
       enabled = true
     }
   }

--- a/aws/redash/local_variables.tf
+++ b/aws/redash/local_variables.tf
@@ -4,9 +4,9 @@ locals {
   container_names = {
     server     = var.prefix == null ? "redash-server" : "${var.prefix}-redash-server"
     worker     = var.prefix == null ? "redash-worker" : "${var.prefix}-redash-worker"
+    db_create  = var.prefix == null ? "redash-db-create" : "${var.prefix}-redash-db-create"
     db_migrate = var.prefix == null ? "redash-db-migrate" : "${var.prefix}-redash-db-migrate"
     db_upgrade = var.prefix == null ? "redash-db-upgrade" : "${var.prefix}-redash-db-upgrade"
-    db_upgrade = var.prefix == null ? "redash-db-create" : "${var.prefix}-redash-db-create"
   }
 
   commands = {

--- a/aws/redash/local_variables.tf
+++ b/aws/redash/local_variables.tf
@@ -1,11 +1,12 @@
 locals {
-  base_name = var.prefix ? "${var.prefix}-redash" : "redash"
+  base_name = var.prefix == null ? "redash" : "${var.prefix}-redash"
 
   container_names = {
-    server     = var.prefix ? "${var.prefix}-redash-server" : "redash-server"
-    worker     = var.prefix ? "${var.prefix}-redash-worker" : "redash-worker"
-    db_migrate = var.prefix ? "${var.prefix}-redash-db-migrate" : "redash-db-migrate"
-    db_upgrate = var.prefix ? "${var.prefix}-redash-db-upgrade" : "redash-db-upgrade"
+    server     = var.prefix == null ? "redash-server" : "${var.prefix}-redash-server"
+    worker     = var.prefix == null ? "redash-worker" : "${var.prefix}-redash-worker"
+    db_migrate = var.prefix == null ? "redash-db-migrate" : "${var.prefix}-redash-db-migrate"
+    db_upgrade = var.prefix == null ? "redash-db-upgrade" : "${var.prefix}-redash-db-upgrade"
+    db_upgrade = var.prefix == null ? "redash-db-create" : "${var.prefix}-redash-db-create"
   }
 
   commands = {

--- a/aws/redash/local_variables.tf
+++ b/aws/redash/local_variables.tf
@@ -12,6 +12,7 @@ locals {
   commands = {
     server     = ["server"]
     worker     = ["scheduler"]
+    db_create  = ["create_db"]
     db_migrate = ["manage", "db", "migrate"]
     db_upgrade = ["manage", "db", "upgrade"]
   }

--- a/aws/redash/local_variables.tf
+++ b/aws/redash/local_variables.tf
@@ -1,0 +1,25 @@
+locals {
+  base_name = var.prefix ? "${var.prefix}-redash" : "redash"
+
+  container_names = {
+    server     = var.prefix ? "${var.prefix}-redash-server" : "redash-server"
+    worker     = var.prefix ? "${var.prefix}-redash-worker" : "redash-worker"
+    db_migrate = var.prefix ? "${var.prefix}-redash-db-migrate" : "redash-db-migrate"
+    db_upgrate = var.prefix ? "${var.prefix}-redash-db-upgrade" : "redash-db-upgrade"
+  }
+
+  commands = {
+    server     = ["server"]
+    worker     = ["scheduler"]
+    db_migrate = ["manage", "db", "migrate"]
+    db_upgrade = ["manage", "db", "upgrade"]
+  }
+
+  port_mappings = [
+    {
+      protocol      = "tcp"
+      containerPort = 5000
+      hostPort      = 5000
+    },
+  ]
+}

--- a/aws/redash/main.tf
+++ b/aws/redash/main.tf
@@ -24,8 +24,8 @@
 *
 *   container_secrets = [
 *     {
-*       name   = "(Secret environment variable name)"
-*       value  = aws_ssm_parameter.xxx.name
+*       name      = "(Secret environment variable name)"
+*       valueFrom = aws_ssm_parameter.xxx.name
 *     },
 *   ]
 *

--- a/aws/redash/main.tf
+++ b/aws/redash/main.tf
@@ -1,0 +1,44 @@
+/**
+* ## Information
+*
+* Create Redash ECS cluster and its Application load balancer.
+*
+* ### Prerequisite
+*
+* N/A
+*
+* ### Usage
+*
+* ```hcl
+* module "redash" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v1.4.0"
+*
+*   container_image_url = "redash/redash:8.0.2.b37747"
+*
+*   container_environments = [
+*     {
+*       name   = "(Environment variable name)"
+*       value  = "(plain string)"
+*     },
+*   ]
+*
+*   container_secrets = [
+*     {
+*       name   = "(Secret environment variable name)"
+*       value  = aws_ssm_parameter.xxx.name
+*     },
+*   ]
+*
+*   ecs_security_group_ids = ["sg-aaa", "sg-bbb"]
+*   ecs_subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+*   ecs_task_role_arn      = "arn:aws:iam:xyz"
+*   lb_access_log_bucket   = "S3 bucket name"
+*   lb_certificate_arn     = "arn:aws:acm:xyz"
+*   lb_security_groups     = ["sg-ccc", "sg-ddd"]
+*   lb_subnets             = ["subnet-ccc", "subnet-ddd"]
+*   prefix                 = "any string"
+*   vpc_id                 = "vpc-xxx"
+* }
+* ```
+*
+*/

--- a/aws/redash/main.tf
+++ b/aws/redash/main.tf
@@ -29,6 +29,7 @@
 *     },
 *   ]
 *
+*   ecs_execution_role_arn = "arn:aws:iam:abc"
 *   ecs_security_group_ids = ["sg-aaa", "sg-bbb"]
 *   ecs_subnet_ids         = ["subnet-aaa", "subnet-bbb"]
 *   ecs_task_role_arn      = "arn:aws:iam:xyz"

--- a/aws/redash/outputs.tf
+++ b/aws/redash/outputs.tf
@@ -1,0 +1,9 @@
+output "lb_dns" {
+  value       = aws_lb.redash.dns_name
+  description = "The DNS name of LB"
+}
+
+output "lb_zone_id" {
+  value       = aws_lb.redash.zone_id
+  description = "The Zone ID of LB"
+}

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -87,7 +87,7 @@ variable "lb_subnets" {
 variable "prefix" {
   type        = string
   description = "A prefix for the resource names"
-  default     = ""
+  default     = null
 }
 
 variable "server_container_cpu" {

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -1,0 +1,121 @@
+variable "cloudwatch_logs_retention_in_days" {
+  type        = number
+  default     = 90
+  description = "The number of days you want to retain log events"
+}
+
+variable "container_environments" {
+  type        = list
+  description = "The environments to set to each ECS container"
+}
+
+variable "container_image_url" {
+  type        = string
+  description = "The URL of the image used to launch the container. Images in the Docker Hub registry available by default"
+}
+
+variable "container_secrets" {
+  type        = list
+  description = "The secrets to set to each ECS container"
+}
+
+variable "db_container_cpu" {
+  type        = number
+  default     = 512
+  description = "The number of cpu units to reserve for the container which is used to kick the DB tasks"
+}
+
+variable "db_container_memory" {
+  type        = number
+  default     = 1024
+  description = "The amount of memory (in MiB) to allow the container to use the DB tasks"
+}
+
+variable "ecs_security_group_ids" {
+  type        = list
+  description = "The list of security group IDs to assign to the ECS task or service"
+}
+
+variable "ecs_subnet_ids" {
+  type        = list
+  description = "The list of subnet IDs to assign to the ECS task or service"
+}
+
+variable "ecs_task_role_arn" {
+  type        = string
+  description = "The ARN of the task execution role"
+}
+
+variable "lb_access_log_bucket" {
+  type        = string
+  default     = null
+  description = "The S3 bucket name to store the logs in"
+}
+
+variable "lb_certificate_arn" {
+  type        = string
+  description = "The ARN of the default SSL server certificate"
+}
+
+variable "lb_security_groups" {
+  type        = list
+  description = "The list of security group IDs to assign to the LB"
+}
+
+variable "lb_ssl_policy" {
+  type        = string
+  default     = "ELBSecurityPolicy-2016-08"
+  description = "The name of the SSL Policy for the listener"
+}
+
+variable "lb_subnets" {
+  type        = list
+  description = "The list of subnet IDs to attach to the LB"
+}
+
+variable "prefix" {
+  type        = string
+  description = "A prefix for the resource names"
+  default     = ""
+}
+
+variable "server_container_cpu" {
+  type        = number
+  default     = 1024
+  description = "The number of cpu units to reserve for the server container"
+}
+
+variable "server_container_memory" {
+  type        = number
+  default     = 2048
+  description = "The amount of memory (in MiB) to allow the server container"
+}
+
+variable "server_desired_count" {
+  type        = number
+  default     = 1
+  description = "The number of redash server tasks"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of VPC where the load balancer is installed"
+}
+
+variable "worker_container_cpu" {
+  type        = number
+  default     = 1024
+  description = "The number of cpu units to reserve for the worker container"
+}
+
+variable "worker_container_memory" {
+  type        = number
+  default     = 2048
+  description = "The amount of memory (in MiB) to allow the worker container"
+}
+
+variable "worker_desired_count" {
+  type        = number
+  default     = 1
+  description = "The number of redash worker tasks"
+}

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -57,6 +57,12 @@ variable "lb_access_log_bucket" {
   description = "The S3 bucket name to store the logs in"
 }
 
+variable "lb_access_log_prefix" {
+  type        = string
+  default     = null
+  description = "The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured"
+}
+
 variable "lb_certificate_arn" {
   type        = string
   description = "The ARN of the default SSL server certificate"

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -31,6 +31,11 @@ variable "db_container_memory" {
   description = "The amount of memory (in MiB) to allow the container to use the DB tasks"
 }
 
+variable "ecs_execution_role_arn" {
+  type        = string
+  description = "The ARN of ECS execution role"
+}
+
 variable "ecs_security_group_ids" {
   type        = list
   description = "The list of security group IDs to assign to the ECS task or service"
@@ -43,7 +48,7 @@ variable "ecs_subnet_ids" {
 
 variable "ecs_task_role_arn" {
   type        = string
-  description = "The ARN of the task execution role"
+  description = "The ARN of the ECS task role"
 }
 
 variable "lb_access_log_bucket" {

--- a/aws/redash/versions.tf
+++ b/aws/redash/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12.2"
+}


### PR DESCRIPTION
This is a PR to save you the hassle of building Redash. Environment variables (even confidential information) that are changed by the user's desires are set in this module to We didn't create it, but passed it as an array.
Therefore, if you use this module, it is not designed to be able to create an ECS Cluster of Redash, but it is thought that it can contribute to saving your resources.