### PR TITLE
Fix a tiny bug in setting to LB access log bucket

### DIFF
--- a/aws/redash/lb.tf
+++ b/aws/redash/lb.tf
@@ -8,7 +8,7 @@ resource "aws_lb" "redash" {
   ip_address_type            = "ipv4"
 
   dynamic "access_logs" {
-    for_each = [var.lb_access_log_bucket]
+    for_each = var.lb_access_log_bucket == null ? [] : [var.lb_access_log_bucket]
 
     content {
       bucket  = access_logs.value


### PR DESCRIPTION
Fix a bug that would cause an error if an empty character is not entered for a module when the LB access log bucket setting is not needed.