### PR TITLE
Topic/assign public ip to ecs service

### DIFF
--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -58,28 +58,28 @@ module "redash" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| assign\_public\_ip | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
+| cloudwatch\_logs\_retention\_in\_days | The number of days you want to retain log events | `number` | `90` | no |
 | container\_environments | The environments to set to each ECS container | `list` | n/a | yes |
 | container\_image\_url | The URL of the image used to launch the container. Images in the Docker Hub registry available by default | `string` | n/a | yes |
 | container\_secrets | The secrets to set to each ECS container | `list` | n/a | yes |
+| db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
+| db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
 | ecs\_execution\_role\_arn | The ARN of ECS execution role | `string` | n/a | yes |
 | ecs\_security\_group\_ids | The list of security group IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_subnet\_ids | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_task\_role\_arn | The ARN of the ECS task role | `string` | n/a | yes |
-| lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
-| lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |
-| lb\_subnets | The list of subnet IDs to attach to the LB | `list` | n/a | yes |
-| vpc\_id | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
-| assign\_public\_ip | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
-| cloudwatch\_logs\_retention\_in\_days | The number of days you want to retain log events | `number` | `90` | no |
-| db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
-| db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
 | lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
 | lb\_access\_log\_prefix | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
+| lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
+| lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |
 | lb\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| lb\_subnets | The list of subnet IDs to attach to the LB | `list` | n/a | yes |
 | prefix | A prefix for the resource names | `string` | `null` | no |
 | server\_container\_cpu | The number of cpu units to reserve for the server container | `number` | `1024` | no |
 | server\_container\_memory | The amount of memory (in MiB) to allow the server container | `number` | `2048` | no |
 | server\_desired\_count | The number of redash server tasks | `number` | `1` | no |
+| vpc\_id | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
 | worker\_container\_cpu | The number of cpu units to reserve for the worker container | `number` | `1024` | no |
 | worker\_container\_memory | The amount of memory (in MiB) to allow the worker container | `number` | `2048` | no |
 | worker\_desired\_count | The number of redash worker tasks | `number` | `1` | no |

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -58,27 +58,28 @@ module "redash" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cloudwatch\_logs\_retention\_in\_days | The number of days you want to retain log events | `number` | `90` | no |
 | container\_environments | The environments to set to each ECS container | `list` | n/a | yes |
 | container\_image\_url | The URL of the image used to launch the container. Images in the Docker Hub registry available by default | `string` | n/a | yes |
 | container\_secrets | The secrets to set to each ECS container | `list` | n/a | yes |
-| db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
-| db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
 | ecs\_execution\_role\_arn | The ARN of ECS execution role | `string` | n/a | yes |
 | ecs\_security\_group\_ids | The list of security group IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_subnet\_ids | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
 | ecs\_task\_role\_arn | The ARN of the ECS task role | `string` | n/a | yes |
-| lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
-| lb\_access\_log\_prefix | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
 | lb\_certificate\_arn | The ARN of the default SSL server certificate | `string` | n/a | yes |
 | lb\_security\_groups | The list of security group IDs to assign to the LB | `list` | n/a | yes |
-| lb\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
 | lb\_subnets | The list of subnet IDs to attach to the LB | `list` | n/a | yes |
-| prefix | A prefix for the resource names | `string` | `""` | no |
+| vpc\_id | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
+| assign\_public\_ip | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
+| cloudwatch\_logs\_retention\_in\_days | The number of days you want to retain log events | `number` | `90` | no |
+| db\_container\_cpu | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
+| db\_container\_memory | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
+| lb\_access\_log\_bucket | The S3 bucket name to store the logs in | `string` | `null` | no |
+| lb\_access\_log\_prefix | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
+| lb\_ssl\_policy | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| prefix | A prefix for the resource names | `string` | `null` | no |
 | server\_container\_cpu | The number of cpu units to reserve for the server container | `number` | `1024` | no |
 | server\_container\_memory | The amount of memory (in MiB) to allow the server container | `number` | `2048` | no |
 | server\_desired\_count | The number of redash server tasks | `number` | `1` | no |
-| vpc\_id | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
 | worker\_container\_cpu | The number of cpu units to reserve for the worker container | `number` | `1024` | no |
 | worker\_container\_memory | The amount of memory (in MiB) to allow the worker container | `number` | `2048` | no |
 | worker\_desired\_count | The number of redash worker tasks | `number` | `1` | no |

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_service" "server" {
   network_configuration {
     security_groups  = var.ecs_security_group_ids
     subnets          = var.ecs_subnet_ids
-    assign_public_ip = false
+    assign_public_ip = var.assign_public_ip
   }
 
   load_balancer {
@@ -65,7 +65,7 @@ resource "aws_ecs_service" "worker" {
   network_configuration {
     security_groups  = var.ecs_security_group_ids
     subnets          = var.ecs_subnet_ids
-    assign_public_ip = false
+    assign_public_ip = var.assign_public_ip
   }
 }
 

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -46,6 +46,12 @@ variable "ecs_subnet_ids" {
   description = "The list of subnet IDs to assign to the ECS task or service"
 }
 
+variable "assign_public_ip" {
+  type        = bool
+  default     = false
+  description = "If true, Public IP is assigned to ECS service"
+}
+
 variable "ecs_task_role_arn" {
   type        = string
   description = "The ARN of the ECS task role"


### PR DESCRIPTION
I just created Re:dash with this module, but it didn't work correctly because of hard-coded value (assign_public_ip).
It cloudn't get the docker image from dockerhub.

This fix makes it selectable whether it uses public ip or not.