### PR TITLE
respond to CORS headers in private-s3-bucket

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -137,6 +137,18 @@ server_side_encryption_configuration = [
 ]
 ```
 
+#### CORS headers
+
+```hcl
+cors_rule = [{
+  allowed_origins = ["*"]
+  allowed_methods = ["GET", "OPTIONS"]
+  allowed_headers = ["*"]
+  expose_headers  = []
+  max_age_seconds = 3000
+}]
+```
+
 ## Requirements
 
 | Name | Version |
@@ -154,11 +166,12 @@ server_side_encryption_configuration = [
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | bucket\_name | S3 bucket name | `string` | n/a | yes |
-| region | S3 bucket region | `string` | n/a | yes |
+| cors\_rule | S3 CORS headers | <pre>list(object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
 | disable\_private | If true, disable private bucket feature | `bool` | `false` | no |
 | grant | S3 grants | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
 | lifecycle\_rule | S3 lifecycle rule | <pre>list(object({<br>    id                                     = string<br>    enabled                                = bool<br>    prefix                                 = string<br>    abort_incomplete_multipart_upload_days = number<br>    tags                                   = map(string)<br>    transition = list(object({<br>      date          = string<br>      days          = number<br>      storage_class = string<br>    }))<br>    # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration<br>    # define as list for simplicity, though expected only a single object<br>    expiration = list(object({<br>      date                         = string<br>      days                         = number<br>      expired_object_delete_marker = bool<br>    }))<br>    noncurrent_version_transition = list(object({<br>      days          = number<br>      storage_class = string<br>    }))<br>    noncurrent_version_expiration = list(object({<br>      days = number<br>    }))<br>  }))</pre> | `[]` | no |
 | logging | S3 access logging | <pre>list(object({<br>    target_bucket = string<br>    target_prefix = string<br>  }))</pre> | `[]` | no |
+| region | S3 bucket region | `string` | n/a | yes |
 | server\_side\_encryption\_configuration | Server-side encryption configuration | <pre>list(object({<br>    rule = object({<br>      apply_server_side_encryption_by_default = object({<br>        sse_algorithm     = string<br>        kms_master_key_id = string<br>      })<br>    })<br>  }))</pre> | `[]` | no |
 | tags | Tags for S3 bucket | `map(string)` | `{}` | no |
 | versioning | S3 object versioning settings | `bool` | `false` | no |

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -226,6 +226,17 @@ resource "aws_s3_bucket" "b" {
       }
     }
   }
+
+  dynamic "cors_rule" {
+    for_each = var.cors_rule
+    content {
+      allowed_headers = cors_rule.value.allowed_headers
+      allowed_methods = cors_rule.value.allowed_methods
+      allowed_origins = cors_rule.value.allowed_origins
+      expose_headers  = cors_rule.value.expose_headers
+      max_age_seconds = cors_rule.value.max_age_seconds
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "b" {

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -137,6 +137,18 @@
 * ]
 * ```
 *
+* #### CORS headers
+*
+* ```hcl
+* cors_rule = [{
+*   allowed_origins = ["*"]
+*   allowed_methods = ["GET", "OPTIONS"]
+*   allowed_headers = ["*"]
+*   expose_headers  = []
+*   max_age_seconds = 3000
+* }]
+* ```
+*
 */
 
 locals {

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -88,3 +88,15 @@ variable "server_side_encryption_configuration" {
   description = "Server-side encryption configuration"
   default     = []
 }
+
+variable "cors_rule" {
+  type = list(object({
+    allowed_headers = list(string)
+    allowed_methods = list(string)
+    allowed_origins = list(string)
+    expose_headers  = list(string)
+    max_age_seconds = number
+  }))
+  description = "S3 CORS headers"
+  default     = []
+}


### PR DESCRIPTION
Makes it choosable whether it set CORS headers or not in S3.

See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#cors_rule