### PR TITLE
Remove aws_s3_bucket region attribute

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -7,9 +7,8 @@ Create a private bucket in a recommended way
 
 ```hcl
 module "bucket" {
-  source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=v1.2.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=v2.1.0"
 
-  region      = "us-east-1"
   bucket_name = "bucket_name"
 
   tags = {
@@ -153,20 +152,19 @@ cors_rule = [{
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.52.0 |
+| aws | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.52.0 |
+| aws | >= 3.0.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | bucket\_name | S3 bucket name | `string` | n/a | yes |
-| region | S3 bucket region | `string` | n/a | yes |
 | cors\_rule | S3 CORS headers | <pre>list(object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
 | disable\_private | If true, disable private bucket feature | `bool` | `false` | no |
 | grant | S3 grants | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |

--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -152,6 +152,7 @@ cors_rule = [{
 
 | Name | Version |
 |------|---------|
+| terraform | >= 0.12.26, < 0.14.0 |
 | aws | >= 3.0.0 |
 
 ## Providers

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 0.12.26, < 0.14.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -1,5 +1,8 @@
 terraform {
   required_providers {
-    aws = ">= 2.52.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
+    }
   }
 }

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -7,9 +7,8 @@
 *
 * ```hcl
 * module "bucket" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=v1.2.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=v2.1.0"
 *
-*   region      = "us-east-1"
 *   bucket_name = "bucket_name"
 *
 *   tags = {
@@ -158,7 +157,6 @@ locals {
 
 resource "aws_s3_bucket" "b" {
   bucket = var.bucket_name
-  region = var.region
   acl    = length(var.grant) > 0 ? null : "private"
   tags   = var.tags
 

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -1,8 +1,3 @@
-variable "region" {
-  type        = string
-  description = "S3 bucket region"
-}
-
 variable "bucket_name" {
   type        = string
   description = "S3 bucket name"


### PR DESCRIPTION
region attribute is readonly from aws-provider v3.0.0

It should be released as v2.1.0, and this should be a breaking change of this module.
It requires terraform v0.12.26 or above