### PR TITLE
Add support for Terraform v0.13

### DIFF
--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -1,7 +1,7 @@
 # Server
 module "server_container_definitions" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.37.0"
+  version = "0.42.0"
 
   container_name   = local.container_names["server"]
   container_image  = var.container_image_url
@@ -28,7 +28,7 @@ module "server_container_definitions" {
 # Worker
 module "worker_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.37.0"
+  version = "0.42.0"
 
   container_name   = local.container_names["worker"]
   container_image  = var.container_image_url
@@ -53,7 +53,7 @@ module "worker_container_definition" {
 # DB Create
 module "db_create_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.37.0"
+  version = "0.42.0"
 
   container_name   = local.container_names["db_create"]
   container_image  = var.container_image_url
@@ -78,7 +78,7 @@ module "db_create_container_definition" {
 # DB Migrate
 module "db_migrate_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.37.0"
+  version = "0.42.0"
 
   container_name   = local.container_names["db_migrate"]
   container_image  = var.container_image_url
@@ -103,7 +103,7 @@ module "db_migrate_container_definition" {
 # DB Upgrade
 module "db_upgrade_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.37.0"
+  version = "0.42.0"
 
   container_name   = local.container_names["db_upgrade"]
   container_image  = var.container_image_url

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "redash" {
 ## Server
 resource "aws_ecs_task_definition" "server" {
   family                   = local.container_names["server"]
-  container_definitions    = module.server_container_definitions.json
+  container_definitions    = module.server_container_definitions.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.server_container_cpu
@@ -44,7 +44,7 @@ resource "aws_ecs_service" "server" {
 ## Worker
 resource "aws_ecs_task_definition" "worker" {
   family                   = local.container_names["worker"]
-  container_definitions    = module.worker_container_definition.json
+  container_definitions    = module.worker_container_definition.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.worker_container_cpu
@@ -72,7 +72,7 @@ resource "aws_ecs_service" "worker" {
 ## DB Create
 resource "aws_ecs_task_definition" "db_create" {
   family                   = local.container_names["db_create"]
-  container_definitions    = module.db_create_container_definition.json
+  container_definitions    = module.db_create_container_definition.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.db_container_cpu
@@ -84,7 +84,7 @@ resource "aws_ecs_task_definition" "db_create" {
 ## DB Migrate
 resource "aws_ecs_task_definition" "db_migrate" {
   family                   = local.container_names["db_migrate"]
-  container_definitions    = module.db_migrate_container_definition.json
+  container_definitions    = module.db_migrate_container_definition.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.db_container_cpu
@@ -96,7 +96,7 @@ resource "aws_ecs_task_definition" "db_migrate" {
 ## DB Upgrade
 resource "aws_ecs_task_definition" "db_upgrade" {
   family                   = local.container_names["db_upgrade"]
-  container_definitions    = module.db_upgrade_container_definition.json
+  container_definitions    = module.db_upgrade_container_definition.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.db_container_cpu


### PR DESCRIPTION
terraform v0.13 に対応するには、cloudposse/ecs-container-definition のversion を0.40.0 以降にする必要があります。
また、outputも変更になっているので json -> json_map_encoded_list に変更する必要があります。