### PR TITLE
Add Athena tables for ALb and NLB access logs

### DIFF
--- a/aws/alb-accesslog-table/README.md
+++ b/aws/alb-accesslog-table/README.md
@@ -1,0 +1,43 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for Application Load Balancer access log
+
+### Usage
+
+```hcl
+module "main" {
+  source = "github.com/elastic-infra/terraform-modules//aws/alb-accesslog-table?ref=v2.2.0"
+
+  name          = "main"
+  database_name = "accesslog"
+  location      = "s3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| database\_name | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase. | `string` | n/a | yes |
+| location | The s3 location of the Application Load Balancer access log. (ex: s3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>) | `string` | n/a | yes |
+| name | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| partition\_range | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/alb-accesslog-table/constraints.tf
+++ b/aws/alb-accesslog-table/constraints.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/aws/alb-accesslog-table/main.tf
+++ b/aws/alb-accesslog-table/main.tf
@@ -1,0 +1,223 @@
+/**
+* ## Information
+*
+* Athena table for Application Load Balancer access log
+*
+* ### Usage
+*
+* ```hcl
+* module "main" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/alb-accesslog-table?ref=v2.2.0"
+*
+*   name          = "main"
+*   database_name = "accesslog"
+*   location      = "s3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+
+      parameters = {
+        "serialization.format" = 1
+        # NOTE: https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
+        "input.regex" = "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) ([^ ]*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^s]+?)\" \"([^s]+)\" \"([^ ]*)\" \"([^ ]*)\""
+      }
+    }
+
+    columns {
+      name = "type"
+      type = "string"
+    }
+
+    columns {
+      name = "time"
+      type = "string"
+    }
+
+    columns {
+      name = "elb"
+      type = "string"
+    }
+
+    columns {
+      name = "client_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "client_port"
+      type = "int"
+    }
+
+    columns {
+      name = "target_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "target_port"
+      type = "int"
+    }
+
+    columns {
+      name = "request_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "target_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "response_processing_time"
+      type = "double"
+    }
+
+    columns {
+      name = "elb_status_code"
+      type = "string"
+    }
+
+    columns {
+      name = "target_status_code"
+      type = "string"
+    }
+
+    columns {
+      name = "received_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sent_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "request_verb"
+      type = "string"
+    }
+
+    columns {
+      name = "request_url"
+      type = "string"
+    }
+
+    columns {
+      name = "request_proto"
+      type = "string"
+    }
+
+    columns {
+      name = "user_agent"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "target_group_arn"
+      type = "string"
+    }
+
+    columns {
+      name = "trace_id"
+      type = "string"
+    }
+
+    columns {
+      name = "domain_name"
+      type = "string"
+    }
+
+    columns {
+      name = "chosen_cert_arn"
+      type = "string"
+    }
+
+    columns {
+      name = "matched_rule_priority"
+      type = "string"
+    }
+
+    columns {
+      name = "request_creation_time"
+      type = "string"
+    }
+
+    columns {
+      name = "actions_executed"
+      type = "string"
+    }
+
+    columns {
+      name = "redirect_url"
+      type = "string"
+    }
+
+    columns {
+      name = "lambda_error_reason"
+      type = "string"
+    }
+
+    columns {
+      name = "target_port_list"
+      type = "string"
+    }
+
+    columns {
+      name = "target_status_code_list"
+      type = "string"
+    }
+
+    columns {
+      name = "classification"
+      type = "string"
+    }
+
+    columns {
+      name = "classification_reason"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+}

--- a/aws/alb-accesslog-table/variables.tf
+++ b/aws/alb-accesslog-table/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]*$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase."
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the Application Load Balancer access log. (ex: s3://your-alb-logs-directory/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}

--- a/aws/nlb-accesslog-table/README.md
+++ b/aws/nlb-accesslog-table/README.md
@@ -1,0 +1,43 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for Network Load Balancer access log
+
+### Usage
+
+```hcl
+module "main" {
+  source = "github.com/elastic-infra/terraform-modules//aws/nlb-accesslog-table?ref=v2.2.0"
+
+  name          = "main"
+  database_name = "accesslog"
+  location      = "s3://your_log_bucket/prefix/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| database\_name | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase. | `string` | n/a | yes |
+| location | The s3 location of the Network Load Balancer access log. (ex: s3://your\_log\_bucket/prefix/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>) | `string` | n/a | yes |
+| name | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| partition\_range | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/nlb-accesslog-table/constraints.tf
+++ b/aws/nlb-accesslog-table/constraints.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/aws/nlb-accesslog-table/main.tf
+++ b/aws/nlb-accesslog-table/main.tf
@@ -1,0 +1,173 @@
+/**
+* ## Information
+*
+* Athena table for Network Load Balancer access log
+*
+* ### Usage
+*
+* ```hcl
+* module "main" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/nlb-accesslog-table?ref=v2.2.0"
+*
+*   name          = "main"
+*   database_name = "accesslog"
+*   location      = "s3://your_log_bucket/prefix/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.RegexSerDe"
+
+      parameters = {
+        "serialization.format" = 1
+        # NOTE: https://docs.aws.amazon.com/athena/latest/ug/networkloadbalancer-classic-logs.html
+        "input.regex" = "([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*):([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-0-9]*) ([-0-9]*) ([-0-9]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*)$"
+      }
+    }
+
+    columns {
+      name = "type"
+      type = "string"
+    }
+
+    columns {
+      name = "version"
+      type = "string"
+    }
+
+    columns {
+      name = "time"
+      type = "string"
+    }
+
+    columns {
+      name = "elb"
+      type = "string"
+    }
+
+    columns {
+      name = "listener_id"
+      type = "string"
+    }
+
+    columns {
+      name = "client_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "client_port"
+      type = "int"
+    }
+
+    columns {
+      name = "target_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "target_port"
+      type = "int"
+    }
+
+    columns {
+      name = "tcp_connection_time_ms"
+      type = "double"
+    }
+
+    columns {
+      name = "tls_handshake_time_ms"
+      type = "double"
+    }
+
+    columns {
+      name = "received_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sent_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "incoming_tls_alert"
+      type = "int"
+    }
+
+    columns {
+      name = "cert_arn"
+      type = "string"
+    }
+
+    columns {
+      name = "certificate_serial"
+      type = "string"
+    }
+
+    columns {
+      name = "tls_cipher_suite"
+      type = "string"
+    }
+
+    columns {
+      name = "tls_protocol_version"
+      type = "string"
+    }
+
+    columns {
+      name = "tls_named_group"
+      type = "string"
+    }
+
+    columns {
+      name = "domain_name"
+      type = "string"
+    }
+
+    columns {
+      name = "alpn_fe_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "alpn_be_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "alpn_client_preference_list"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+}

--- a/aws/nlb-accesslog-table/variables.tf
+++ b/aws/nlb-accesslog-table/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]*$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be all lowercase."
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the Network Load Balancer access log. (ex: s3://your_log_bucket/prefix/AWSLogs/<ACCOUNT-ID>/elasticloadbalancing/<REGION>)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}


### PR DESCRIPTION
This module create tables for ALB and NLB Logs.
Table schema refer to below urls.

https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html
https://docs.aws.amazon.com/athena/latest/ug/networkloadbalancer-classic-logs.html

And the tables use [Partition Projection](https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html).