### PR TITLE
Passing Providers

### DIFF
--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -12,7 +12,7 @@ Users of this module need to set up the requester side in other means in advance
 
 ```hcl
 module "peering_acceptance" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v1.2.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v2.3.0"
 
   enabled                   = "true"
   namespace                 = "foo"
@@ -20,19 +20,24 @@ module "peering_acceptance" {
   name                      = "bar"
   delimiter                 = "-"
   requester_vpc_cidr_blocks = ["198.51.100/24"]
-  accepter_region           = "us-east-1"
   accepter_vpc_id           = "vpc-0123456789"
   vpc_peering_id            = "pcx-0123456789abcdef"
 
   tags {
     Environment = "development"
   }
+
+  providers = {
+    aws.accepter = aws.us-east-1
+  }
 }
 ```
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
 
 ## Providers
 
@@ -44,7 +49,6 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | name | Name  (e.g. `app` or `cluster`) | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | n/a | yes |
 | requester\_vpc\_cidr\_blocks | CIDR blocks associated with the peer VPC (it should be fetched via VPC peering information but terraform-provider-aws does not read CidrBlockSet) | `list(string)` | n/a | yes |

--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -28,7 +28,7 @@ module "peering_acceptance" {
   }
 
   providers = {
-    aws.accepter = aws.us-east-1
+    aws = aws.us-east-1
   }
 }
 ```
@@ -43,7 +43,7 @@ module "peering_acceptance" {
 
 | Name | Version |
 |------|---------|
-| aws.accepter | n/a |
+| aws | n/a |
 
 ## Inputs
 

--- a/aws/vpc-peering-accepter-multiaccount/accepter.tf
+++ b/aws/vpc-peering-accepter-multiaccount/accepter.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  alias  = "accepter"
-  region = var.accepter_region
+  alias = "accepter"
 }
 
 locals {

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -12,7 +12,7 @@
 *
 * ```hcl
 * module "peering_acceptance" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v1.2.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v2.3.0"
 *
 *   enabled                   = "true"
 *   namespace                 = "foo"
@@ -20,12 +20,15 @@
 *   name                      = "bar"
 *   delimiter                 = "-"
 *   requester_vpc_cidr_blocks = ["198.51.100/24"]
-*   accepter_region           = "us-east-1"
 *   accepter_vpc_id           = "vpc-0123456789"
 *   vpc_peering_id            = "pcx-0123456789abcdef"
 *
 *   tags {
 *     Environment = "development"
+*   }
+*
+*   providers = {
+*     aws.accepter = aws.us-east-1
 *   }
 * }
 * ```
@@ -34,4 +37,8 @@
 locals {
   enabled = var.enabled == "true"
   count   = local.enabled ? 1 : 0
+}
+
+terraform {
+  required_version = ">= 0.13"
 }

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -28,7 +28,7 @@
 *   }
 *
 *   providers = {
-*     aws.accepter = aws.us-east-1
+*     aws = aws.us-east-1
 *   }
 * }
 * ```

--- a/aws/vpc-peering-accepter-multiaccount/variables.tf
+++ b/aws/vpc-peering-accepter-multiaccount/variables.tf
@@ -47,11 +47,6 @@ variable "requester_vpc_cidr_blocks" {
   type        = list(string)
 }
 
-variable "accepter_region" {
-  description = "Accepter AWS region"
-  type        = string
-}
-
 variable "accepter_vpc_id" {
   description = "Accepter VPC ID filter"
   type        = string

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -30,7 +30,7 @@ module "peering-request" {
   }
 
   providers = {
-    aws.requester = aws.us-east-1
+    aws = aws.us-east-1
   }
 }
 ```
@@ -45,7 +45,7 @@ module "peering-request" {
 
 | Name | Version |
 |------|---------|
-| aws.requester | n/a |
+| aws | n/a |
 
 ## Inputs
 

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -13,14 +13,13 @@ set up the route to the requester.
 
 ```hcl
 module "peering-request" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v1.2.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v2.3.0"
 
   enabled              = "true"
   namespace            = "foo"
   stage                = "dev"
   name                 = "bar"
   delimiter            = "-"
-  requester_region     = "us-east-1"
   requester_vpc_id     = "vpc-12345678"
   peer_owner_id        = "012345678901"
   peer_vpc_id          = "vpc-0123456789abcdef"
@@ -29,12 +28,18 @@ module "peering-request" {
   tags {
     Environment = "development"
   }
+
+  providers = {
+    aws.requester = aws.us-east-1
+  }
 }
 ```
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
 
 ## Providers
 
@@ -52,7 +57,6 @@ No requirements.
 | peer\_region | Region where peer VPC resides | `string` | n/a | yes |
 | peer\_vpc\_cidr\_blocks | CIDR blocks associated with the peer VPC | `list(string)` | n/a | yes |
 | peer\_vpc\_id | Peer VPC ID | `string` | n/a | yes |
-| requester\_region | Requester AWS region | `string` | n/a | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
 | attributes | Additional attributes (e.g. `a` or `b`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | `string` | `"-"` | no |

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -14,14 +14,13 @@
 *
 * ```hcl
 * module "peering-request" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v1.2.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v2.3.0"
 *
 *   enabled              = "true"
 *   namespace            = "foo"
 *   stage                = "dev"
 *   name                 = "bar"
 *   delimiter            = "-"
-*   requester_region     = "us-east-1"
 *   requester_vpc_id     = "vpc-12345678"
 *   peer_owner_id        = "012345678901"
 *   peer_vpc_id          = "vpc-0123456789abcdef"
@@ -30,6 +29,10 @@
 *   tags {
 *     Environment = "development"
 *   }
+*
+*   providers = {
+*     aws.requester = aws.us-east-1
+*   }
 * }
 * ```
 */
@@ -37,4 +40,8 @@
 locals {
   enabled = var.enabled == "true"
   count   = local.enabled ? 1 : 0
+}
+
+terraform {
+  required_version = ">= 0.13"
 }

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -31,7 +31,7 @@
 *   }
 *
 *   providers = {
-*     aws.requester = aws.us-east-1
+*     aws = aws.us-east-1
 *   }
 * }
 * ```

--- a/aws/vpc-peering-requester-multiaccount/requester.tf
+++ b/aws/vpc-peering-requester-multiaccount/requester.tf
@@ -1,6 +1,5 @@
 provider "aws" {
-  alias  = "requester"
-  region = var.requester_region
+  alias = "requester"
 }
 
 locals {

--- a/aws/vpc-peering-requester-multiaccount/variables.tf
+++ b/aws/vpc-peering-requester-multiaccount/variables.tf
@@ -37,11 +37,6 @@ variable "tags" {
   description = "Additional tags (e.g. `{\"BusinessUnit\" = \"XYZ\"`)"
 }
 
-variable "requester_region" {
-  type        = string
-  description = "Requester AWS region"
-}
-
 variable "requester_vpc_id" {
   type        = string
   description = "Requester VPC ID filter"


### PR DESCRIPTION
Terraform 0.13+ support using provider configurations in a module block, so fix `vpc-peering-accepter-multiaccount` and `vpc-peering-requester-multiaccount` modules.

https://www.terraform.io/docs/configuration/modules.html#passing-providers-explicitly