### PR TITLE
Add Athena table for WAF

### DIFF
--- a/aws/waf-log-table/README.md
+++ b/aws/waf-log-table/README.md
@@ -1,0 +1,43 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for WAF log
+
+### Usage
+
+```hcl
+module "main" {
+  source = "github.com/elastic-infra/terraform-modules//aws/waf-log-table?ref=v2.4.0"
+
+  name          = "main"
+  database_name = "waflog"
+  location      = "s3://athenawaflogs/WebACL/"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| database\_name | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| location | The s3 location of the WAF log. (ex: s3://athenawaflogs/WebACL/) | `string` | n/a | yes |
+| name | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| partition\_range | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/waf-log-table/constraints.tf
+++ b/aws/waf-log-table/constraints.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/aws/waf-log-table/main.tf
+++ b/aws/waf-log-table/main.tf
@@ -1,0 +1,122 @@
+/**
+* ## Information
+*
+* Athena table for WAF log
+*
+* ### Usage
+*
+* ```hcl
+* module "main" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/waf-log-table?ref=v2.4.0"
+*
+*   name          = "main"
+*   database_name = "waflog"
+*   location      = "s3://athenawaflogs/WebACL/"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+
+      parameters = {
+        # NOTE: https://docs.aws.amazon.com/athena/latest/ug/waf-logs.html
+        "paths" = "action,formatVersion,httpRequest,httpSourceId,httpSourceName,nonTerminatingMatchingRules,rateBasedRuleList,ruleGroupList,terminatingRuleId,terminatingRuleMatchDetails,terminatingRuleType,timestamp,webaclId"
+      }
+    }
+
+    columns {
+      name = "timestamp"
+      type = "bigint"
+    }
+
+    columns {
+      name = "formatversion"
+      type = "int"
+    }
+
+    columns {
+      name = "webaclid"
+      type = "string"
+    }
+
+    columns {
+      name = "terminatingruleid"
+      type = "string"
+    }
+
+    columns {
+      name = "terminatingruletype"
+      type = "string"
+    }
+
+    columns {
+      name = "action"
+      type = "string"
+    }
+
+    columns {
+      name = "terminatingrulematchdetails"
+      type = "array<struct<conditiontype:string,location:string,matcheddata:array<string>>>"
+    }
+
+    columns {
+      name = "httpsourcename"
+      type = "string"
+    }
+
+    columns {
+      name = "httpsourceid"
+      type = "string"
+    }
+
+    columns {
+      name = "rulegrouplist"
+      type = "array<struct<rulegroupid:string,terminatingrule:struct<ruleid:string,action:string,rulematchdetails:string>,nonterminatingmatchingrules:array<struct<ruleid:string,action:string,rulematchdetails:array<struct<conditiontype:string,location:string,matcheddata:array<string>>>>>,excludedrules:string>>"
+    }
+
+    columns {
+      name = "ratebasedrulelist"
+      type = "array<struct<ratebasedruleid:string,limitkey:string,maxrateallowed:int>>"
+    }
+
+    columns {
+      name = "nonterminatingmatchingrules"
+      type = "array<struct<ruleid:string,action:string>>"
+    }
+
+    columns {
+      name = "httprequest"
+      type = "struct<clientip:string,country:string,headers:array<struct<name:string,value:string>>,uri:string,args:string,httpversion:string,httpmethod:string,requestid:string>"
+    }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+}

--- a/aws/waf-log-table/variables.tf
+++ b/aws/waf-log-table/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]+$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the WAF log. (ex: s3://athenawaflogs/WebACL/)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}


### PR DESCRIPTION
This module create tables for WAF Logs.
Table schema refer to below urls.

https://docs.aws.amazon.com/athena/latest/ug/waf-logs.html