### PR TITLE
fix variable conditions

### DIFF
--- a/aws/alb-accesslog-table/variables.tf
+++ b/aws/alb-accesslog-table/variables.tf
@@ -13,7 +13,7 @@ variable "database_name" {
   description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
 
   validation {
-    condition     = can(regex("^[0-9a-z_-]+$", var.name))
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
     error_message = "The name value must be entirely lowercase."
   }
 }

--- a/aws/nlb-accesslog-table/variables.tf
+++ b/aws/nlb-accesslog-table/variables.tf
@@ -13,7 +13,7 @@ variable "database_name" {
   description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
 
   validation {
-    condition     = can(regex("^[0-9a-z_-]+$", var.name))
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
     error_message = "The name value must be entirely lowercase."
   }
 }


### PR DESCRIPTION
fix: https://github.com/elastic-infra/terraform-modules/pull/23

```
Error: Invalid variable validation condition

  on .terraform/modules/accesslog_table/aws/alb-accesslog-table/variables.tf line 16, in variable "database_name":
  16:     condition     = can(regex("^[0-9a-z_-]+$", var.name))

The condition for variable "database_name" must refer to var.database_name in
order to test incoming values.
```