### PR TITLE
Feature/allow tf v15

### DIFF
--- a/aws/ei-base-role/README.md
+++ b/aws/ei-base-role/README.md
@@ -21,7 +21,7 @@ module "ei_base_role" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0, < 0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0, < 0.16 |
 
 ## Providers
 

--- a/aws/ei-base-role/versions.tf
+++ b/aws/ei-base-role/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.15"
+  required_version = ">= 0.12.0, < 0.16"
 }

--- a/aws/iam-service-role/README.md
+++ b/aws/iam-service-role/README.md
@@ -21,7 +21,7 @@ module "service_role" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6, < 0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6, < 0.16 |
 
 ## Providers
 

--- a/aws/iam-service-role/versions.tf
+++ b/aws/iam-service-role/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.15"
+  required_version = ">= 0.12.6, < 0.16"
 }

--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -152,7 +152,7 @@ cors_rule = [{
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26, < 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26, < 0.16.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0.0 |
 
 ## Providers

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26, < 0.15.0"
+  required_version = ">= 0.12.26, < 0.16.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -46,7 +46,7 @@ module "redash" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 0.15 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 0.16 |
 
 ## Providers
 

--- a/aws/redash/versions.tf
+++ b/aws/redash/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.2, < 0.15"
+  required_version = ">= 0.12.2, < 0.16"
 }


### PR DESCRIPTION
Terraform v0.15.4 is released on May 19, 2021. It’s a time to try the latest version.