### PR TITLE
the list&map functions was deprecated in terraform v0.12 or higher

### DIFF
--- a/aws/vpc-peering-accepter-multiaccount/accepter.tf
+++ b/aws/vpc-peering-accepter-multiaccount/accepter.tf
@@ -1,6 +1,6 @@
 locals {
-  accepter_attributes = concat(var.attributes, list("accepter"))
-  accepter_tags       = merge(var.tags, map("Side", "accepter"))
+  accepter_attributes = concat(var.attributes, tolist(["accepter"]))
+  accepter_tags       = merge(var.tags, tomap({"Side" = "accepter"}))
 }
 
 module "accepter" {

--- a/aws/vpc-peering-accepter-multiaccount/accepter.tf
+++ b/aws/vpc-peering-accepter-multiaccount/accepter.tf
@@ -1,6 +1,6 @@
 locals {
-  accepter_attributes = concat(var.attributes, tolist(["accepter"]))
-  accepter_tags       = merge(var.tags, tomap({"Side" = "accepter"}))
+  accepter_attributes = concat(var.attributes, ["accepter"])
+  accepter_tags       = merge(var.tags, {"Side" = "accepter"})
 }
 
 module "accepter" {

--- a/aws/vpc-peering-requester-multiaccount/requester.tf
+++ b/aws/vpc-peering-requester-multiaccount/requester.tf
@@ -1,6 +1,6 @@
 locals {
-  requester_attributes = concat(var.attributes, list("requester"))
-  requester_tags       = merge(var.tags, map("Side", "requester"))
+  requester_attributes = concat(var.attributes, tolist(["requester"]))
+  requester_tags       = merge(var.tags, tomap({"Side" = "requester"}))
 }
 
 module "requester" {

--- a/aws/vpc-peering-requester-multiaccount/requester.tf
+++ b/aws/vpc-peering-requester-multiaccount/requester.tf
@@ -1,6 +1,6 @@
 locals {
-  requester_attributes = concat(var.attributes, tolist(["requester"]))
-  requester_tags       = merge(var.tags, tomap({"Side" = "requester"}))
+  requester_attributes = concat(var.attributes, ["requester"])
+  requester_tags       = merge(var.tags, {"Side" = "requester"})
 }
 
 module "requester" {


### PR DESCRIPTION
The `list` and `map` functions was deprecated in terraform v0.12 or higher.