### PR TITLE
Add EI PrivateLink module for consumer

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -1,0 +1,62 @@
+## Information
+
+Elastic Infra - PrivateLink Consumer Resource
+
+### Notice
+
+Private DNS can only be enabled after the endpoint connection is accepted.
+
+So it needs to set private_dns_enabled variable to false at your first applying.
+
+### Usage
+
+```hcl
+module "ei_privatelink_consumer" {
+  source             = "../module/aws/common/ei-privatelink-consumer"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.public_subnets
+  security_group_ids = [module.vpc.default_security_group_id]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_security_group.ei_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
+| <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region of the VPC Endpoints | `string` | `"ap-northeast-1"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ei_managed_sg_id"></a> [ei\_managed\_sg\_id](#output\_ei\_managed\_sg\_id) | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -5,7 +5,7 @@ locals {
 
 resource "aws_vpc_endpoint" "this" {
   vpc_id              = var.vpc_id
-  service_name        = local.service_name
+  service_name        = local.vpce_service_name
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = [aws_security_group.this.id]

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -1,0 +1,47 @@
+locals {
+  vpce_service_name = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
+  ei_sg_id          = "vpc-8d510ae8"
+}
+
+resource "aws_vpc_endpoint" "this" {
+  vpc_id              = var.vpc_id
+  service_name        = local.service_name
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [aws_security_group.this.id]
+  private_dns_enabled = var.private_dns_enabled
+  tags = {
+    Name = "Elastic Infra Common Service"
+  }
+}
+
+resource "aws_security_group" "this" {
+  name   = "elastic-infra-common-service"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = [aws_security_group.ei_managed.id]
+  }
+}
+
+resource "aws_security_group" "ei_managed" {
+  name   = "ei-managed"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port       = -1
+    to_port         = -1
+    protocol        = "icmp"
+    security_groups = [local.ei_sg_id]
+  }
+
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [local.ei_sg_id]
+  }
+}

--- a/aws/ei-privatelink-consumer/output.tf
+++ b/aws/ei-privatelink-consumer/output.tf
@@ -1,0 +1,3 @@
+output "ei_managed_sg_id" {
+  value = aws_security_group.ei_managed.id
+}

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  type        = string
+  description = "AWS region of the VPC Endpoints"
+  default     = "ap-northeast-1"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID where the VPC Endpoints are installed"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The ID of one or more subnets in which to create a network interface for the endpoint"
+}
+
+variable "private_dns_enabled" {
+  type        = bool
+  description = "Whether or not to associate a private hosted zone with the specified VPC"
+  default     = true
+}

--- a/aws/ei-privatelink-consumer/versions.tf
+++ b/aws/ei-privatelink-consumer/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This module creates VPCe and Security Groups to use PrivateLink.
If you attach output security group to EC2, it can access EI common services.