### PR TITLE
change ei_sg_id to variable

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -50,6 +50,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
+| <a name="input_ei_sg_id"></a> [ei\_sg\_id](#input\_ei\_sg\_id) | Security Group ID of EI Management Environment | `string` | `"089928438340/sg-3845ff5c"` | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region of the VPC Endpoints | `string` | `"ap-northeast-1"` | no |
 

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -1,6 +1,5 @@
 locals {
   vpce_service_name = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
-  ei_sg_id          = "sg-3845ff5c"
 }
 
 resource "aws_vpc_endpoint" "this" {
@@ -35,13 +34,13 @@ resource "aws_security_group" "ei_managed" {
     from_port       = -1
     to_port         = -1
     protocol        = "icmp"
-    security_groups = [local.ei_sg_id]
+    security_groups = [var.ei_sg_id]
   }
 
   ingress {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    security_groups = [local.ei_sg_id]
+    security_groups = [var.ei_sg_id]
   }
 }

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -19,3 +19,9 @@ variable "private_dns_enabled" {
   description = "Whether or not to associate a private hosted zone with the specified VPC"
   default     = true
 }
+
+variable "ei_sg_id" {
+  type        = string
+  description = "Security Group ID of EI Management Environment"
+  default     = "089928438340/sg-3845ff5c"
+}


### PR DESCRIPTION
fix: https://github.com/elastic-infra/terraform-modules/pull/36

When you create Security Group for cross account, ei_sg_id references EI aws account id.