### PR TITLE
Output list of IAM policies attached to the base instance profile

### DIFF
--- a/aws/ei-base-role/README.md
+++ b/aws/ei-base-role/README.md
@@ -59,6 +59,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_attached_policy_arns"></a> [attached\_policy\_arns](#output\_attached\_policy\_arns) | List of ARNs for IAM policy attached to the base instance profile |
 | <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | ARN of Base policy |
 | <a name="output_profile_name"></a> [profile\_name](#output\_profile\_name) | Name of Base instance profile |
 

--- a/aws/ei-base-role/output.tf
+++ b/aws/ei-base-role/output.tf
@@ -7,3 +7,15 @@ output "policy_arn" {
   value       = aws_iam_policy.ei_base.arn
   description = "ARN of Base policy"
 }
+
+output "attached_policy_arns" {
+  value = concat(
+    [
+      aws_iam_policy.ei_base.arn,
+      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    ],
+    var.additional_policy_arns,
+  )
+
+  description = "List of ARNs for IAM policy attached to the base instance profile"
+}


### PR DESCRIPTION
When we create new instance profile using `iam-service-role` module, we need to specify `AmazonSSMManagedInstanceCore` policy and `ei-base-role.policy_arn` in `iam-service-role.role_policy_arns`.

To prevent omission of specifying `AmazonSSMManagedInstanceCore`, all policies will be output.

### before
```hcl
module "ei_base_role" {
  source = "github.com/elastic-infra/terraform-modules//aws/ei-base-role?ref=master"
}

module "ec2_role" {
  source = "github.com/elastic-infra/terraform-modules//aws/iam-service-role?ref=master"

  name             = "ec2"
  trusted_services = ["ec2.amazonaws.com"]

  role_policy_arns = [
    module.ei_base_role.policy_arn,
    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
  ]
  role_inline_policies = [
    {
      name   = "SomeCustomPolicy"
      policy = data.aws_iam_policy_document.some_custom_policy.json
    },
  ]

  create_instance_profile = true
}
```

### after
```hcl
module "ei_base_role" {
  source = "github.com/elastic-infra/terraform-modules//aws/ei-base-role?ref=master"
}

module "ec2_role" {
  source = "github.com/elastic-infra/terraform-modules//aws/iam-service-role?ref=master"

  name             = "ec2"
  trusted_services = ["ec2.amazonaws.com"]

  role_policy_arns = module.ei_base_role.attached_policy_arns
  role_inline_policies = [
    {
      name   = "SomeCustomPolicy"
      policy = data.aws_iam_policy_document.some_custom_policy.json
    },
  ]

  create_instance_profile = true
}
```