### PR TITLE
enable to switch VPCe service_name per region

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -43,6 +43,7 @@ No modules.
 | [aws_security_group.ei_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -52,7 +53,6 @@ No modules.
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
 | <a name="input_ei_sg_id"></a> [ei\_sg\_id](#input\_ei\_sg\_id) | Security Group ID of EI Management Environment | `string` | `"089928438340/sg-3845ff5c"` | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS region of the VPC Endpoints | `string` | `"ap-northeast-1"` | no |
 
 ## Outputs
 

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -1,10 +1,13 @@
 locals {
-  vpce_service_name = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
+  vpce_service_name = {
+    "ap-northeast-1" = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
+    "us-east-1"      = "com.amazonaws.vpce.us-east-1.vpce-svc-0d87332b34a7a49dc"
+  }
 }
 
 resource "aws_vpc_endpoint" "this" {
   vpc_id              = var.vpc_id
-  service_name        = local.vpce_service_name
+  service_name        = local.vpce_service_name[var.region]
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = [aws_security_group.this.id]

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -5,9 +5,11 @@ locals {
   }
 }
 
+data "aws_region" "current" {}
+
 resource "aws_vpc_endpoint" "this" {
   vpc_id              = var.vpc_id
-  service_name        = local.vpce_service_name[var.region]
+  service_name        = local.vpce_service_name[data.aws_region.current.name]
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = [aws_security_group.this.id]

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  type        = string
-  description = "AWS region of the VPC Endpoints"
-  default     = "ap-northeast-1"
-}
-
 variable "vpc_id" {
   type        = string
   description = "VPC ID where the VPC Endpoints are installed"


### PR DESCRIPTION
I added VPCe Service in us-east-1 region.
And removed unncessary variable "region".