### PR TITLE
Topic/apply for Inter-region peering

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -51,8 +51,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
-| <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | Cidr block of EI Management Environment | `list(string)` | <pre>[<br>  "10.254.0.0/23"<br>]</pre> | no |
-| <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group ID of EI Management Environment | `list(string)` | <pre>[<br>  "089928438340/sg-3845ff5c"<br>]</pre> | no |
+| <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | CIDR blocks of EI Management Environment | `list(string)` | <pre>[<br>  "10.254.0.0/23"<br>]</pre> | no |
+| <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group IDs of EI Management Environment | `list(string)` | <pre>[<br>  "089928438340/sg-3845ff5c"<br>]</pre> | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
 
 ## Outputs

--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -51,8 +51,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
-| <a name="input_ei_cidr"></a> [ei\_cidr](#input\_ei\_cidr) | Cidr block of EI Management Environment | `string` | `"10.254.0.0/23"` | no |
-| <a name="input_ei_sg_id"></a> [ei\_sg\_id](#input\_ei\_sg\_id) | Security Group ID of EI Management Environment | `string` | `"089928438340/sg-3845ff5c"` | no |
+| <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | Cidr block of EI Management Environment | `list(string)` | <pre>[<br>  "10.254.0.0/23"<br>]</pre> | no |
+| <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group ID of EI Management Environment | `list(string)` | <pre>[<br>  "089928438340/sg-3845ff5c"<br>]</pre> | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
 
 ## Outputs

--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -51,6 +51,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
+| <a name="input_ei_cidr"></a> [ei\_cidr](#input\_ei\_cidr) | Cidr block of EI Management Environment | `string` | `"10.254.0.0/23"` | no |
 | <a name="input_ei_sg_id"></a> [ei\_sg\_id](#input\_ei\_sg\_id) | Security Group ID of EI Management Environment | `string` | `"089928438340/sg-3845ff5c"` | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
 

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -3,8 +3,8 @@ locals {
     "ap-northeast-1" = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
     "us-east-1"      = "com.amazonaws.vpce.us-east-1.vpce-svc-0d87332b34a7a49dc"
   }
-  ei_sg_id = data.aws_region.current.name == "ap-northeast-1" ? [var.ei_sg_id] : []
-  ei_cidr  = data.aws_region.current.name == "ap-northeast-1" ? [] : [var.ei_cidr]
+  ei_sg_ids = data.aws_region.current.name == "ap-northeast-1" ? [var.ei_sg_ids] : []
+  ei_cidrs  = data.aws_region.current.name == "ap-northeast-1" ? [] : [var.ei_cidrs]
 }
 
 data "aws_region" "current" {}
@@ -38,46 +38,46 @@ resource "aws_security_group" "ei_managed" {
   vpc_id = var.vpc_id
 
   dynamic "ingress" {
-    for_each = local.ei_sg_id
+    for_each = local.ei_sg_ids
 
     content {
       from_port       = -1
       to_port         = -1
       protocol        = "icmp"
-      security_groups = [ingress.value]
+      security_groups = ingress.value
     }
   }
 
   dynamic "ingress" {
-    for_each = local.ei_sg_id
+    for_each = local.ei_sg_ids
 
     content {
       from_port       = 22
       to_port         = 22
       protocol        = "tcp"
-      security_groups = [ingress.value]
+      security_groups = ingress.value
     }
   }
 
   dynamic "ingress" {
-    for_each = local.ei_cidr
+    for_each = local.ei_cidrs
 
     content {
       from_port   = -1
       to_port     = -1
       protocol    = "icmp"
-      cidr_blocks = [ingress.value]
+      cidr_blocks = ingress.value
     }
   }
 
   dynamic "ingress" {
-    for_each = local.ei_cidr
+    for_each = local.ei_cidrs
 
     content {
       from_port   = 22
       to_port     = 22
       protocol    = "tcp"
-      cidr_blocks = [ingress.value]
+      cidr_blocks = ingress.value
     }
   }
 }

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -3,6 +3,8 @@ locals {
     "ap-northeast-1" = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-0bbba1a5d2095d2c3"
     "us-east-1"      = "com.amazonaws.vpce.us-east-1.vpce-svc-0d87332b34a7a49dc"
   }
+  ei_sg_id = data.aws_region.current.name == "ap-northeast-1" ? [var.ei_sg_id] : []
+  ei_cidr  = data.aws_region.current.name == "ap-northeast-1" ? [] : [var.ei_cidr]
 }
 
 data "aws_region" "current" {}
@@ -35,17 +37,47 @@ resource "aws_security_group" "ei_managed" {
   name   = "ei-managed"
   vpc_id = var.vpc_id
 
-  ingress {
-    from_port       = -1
-    to_port         = -1
-    protocol        = "icmp"
-    security_groups = [var.ei_sg_id]
+  dynamic "ingress" {
+    for_each = local.ei_sg_id
+
+    content {
+      from_port       = -1
+      to_port         = -1
+      protocol        = "icmp"
+      security_groups = [ingress.value]
+    }
   }
 
-  ingress {
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    security_groups = [var.ei_sg_id]
+  dynamic "ingress" {
+    for_each = local.ei_sg_id
+
+    content {
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      security_groups = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = local.ei_cidr
+
+    content {
+      from_port   = -1
+      to_port     = -1
+      protocol    = "icmp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = local.ei_cidr
+
+    content {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
   }
 }

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -19,3 +19,9 @@ variable "ei_sg_id" {
   description = "Security Group ID of EI Management Environment"
   default     = "089928438340/sg-3845ff5c"
 }
+
+variable "ei_cidr" {
+  type        = string
+  description = "Cidr block of EI Management Environment"
+  default     = "10.254.0.0/23"
+}

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -16,12 +16,12 @@ variable "private_dns_enabled" {
 
 variable "ei_sg_ids" {
   type        = list(string)
-  description = "Security Group ID of EI Management Environment"
+  description = "Security Group IDs of EI Management Environment"
   default     = ["089928438340/sg-3845ff5c"]
 }
 
 variable "ei_cidrs" {
   type        = list(string)
-  description = "Cidr block of EI Management Environment"
+  description = "CIDR blocks of EI Management Environment"
   default     = ["10.254.0.0/23"]
 }

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -14,14 +14,14 @@ variable "private_dns_enabled" {
   default     = true
 }
 
-variable "ei_sg_id" {
-  type        = string
+variable "ei_sg_ids" {
+  type        = list(string)
   description = "Security Group ID of EI Management Environment"
-  default     = "089928438340/sg-3845ff5c"
+  default     = ["089928438340/sg-3845ff5c"]
 }
 
-variable "ei_cidr" {
-  type        = string
+variable "ei_cidrs" {
+  type        = list(string)
   description = "Cidr block of EI Management Environment"
-  default     = "10.254.0.0/23"
+  default     = ["10.254.0.0/23"]
 }


### PR DESCRIPTION
fix https://github.com/elastic-infra/terraform-modules/pull/40

https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html

> You cannot reference the security group of a peer VPC that's in a different Region. Instead, use the CIDR block of the peer VPC.

EI Management Env is in ap-northeast-1.
We have to use CIDR block to use this module in another region.