### PR TITLE
Fix required_version

### DIFF
--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26, < 1.1.0"
+  required_version = ">= 0.14, < 1.1.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
fixed at: https://github.com/elastic-infra/terraform-modules/pull/43

`alltrue` is available in version 0.14 and later.