### PR TITLE
Add scheduler for redash v10

### DIFF
--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -11,9 +11,9 @@ N/A
 
 ```hcl
 module "redash" {
-  source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v1.4.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v3.4.0"
 
-  container_image_url = "redash/redash:8.0.2.b37747"
+  container_image_url = "redash/redash:10.1.0.b50633"
 
   container_environments = [
     {
@@ -46,7 +46,7 @@ module "redash" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 0.16 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 1.1.0 |
 
 ## Providers
 
@@ -58,11 +58,12 @@ module "redash" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_db_create_container_definition"></a> [db\_create\_container\_definition](#module\_db\_create\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.56.0 |
-| <a name="module_db_migrate_container_definition"></a> [db\_migrate\_container\_definition](#module\_db\_migrate\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.56.0 |
-| <a name="module_db_upgrade_container_definition"></a> [db\_upgrade\_container\_definition](#module\_db\_upgrade\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.56.0 |
-| <a name="module_server_container_definitions"></a> [server\_container\_definitions](#module\_server\_container\_definitions) | cloudposse/ecs-container-definition/aws | 0.56.0 |
-| <a name="module_worker_container_definition"></a> [worker\_container\_definition](#module\_worker\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.56.0 |
+| <a name="module_db_create_container_definition"></a> [db\_create\_container\_definition](#module\_db\_create\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_db_migrate_container_definition"></a> [db\_migrate\_container\_definition](#module\_db\_migrate\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_db_upgrade_container_definition"></a> [db\_upgrade\_container\_definition](#module\_db\_upgrade\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_scheduler_container_definition"></a> [scheduler\_container\_definition](#module\_scheduler\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_server_container_definitions"></a> [server\_container\_definitions](#module\_server\_container\_definitions) | cloudposse/ecs-container-definition/aws | 0.58.1 |
+| <a name="module_worker_container_definition"></a> [worker\_container\_definition](#module\_worker\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
 
 ## Resources
 
@@ -87,16 +88,16 @@ module "redash" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_container_environments"></a> [container\_environments](#input\_container\_environments) | The environments to set to each ECS container | `list` | n/a | yes |
+| <a name="input_container_environments"></a> [container\_environments](#input\_container\_environments) | The environments to set to each ECS container | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | n/a | yes |
 | <a name="input_container_image_url"></a> [container\_image\_url](#input\_container\_image\_url) | The URL of the image used to launch the container. Images in the Docker Hub registry available by default | `string` | n/a | yes |
-| <a name="input_container_secrets"></a> [container\_secrets](#input\_container\_secrets) | The secrets to set to each ECS container | `list` | n/a | yes |
+| <a name="input_container_secrets"></a> [container\_secrets](#input\_container\_secrets) | The secrets to set to each ECS container | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | n/a | yes |
 | <a name="input_ecs_execution_role_arn"></a> [ecs\_execution\_role\_arn](#input\_ecs\_execution\_role\_arn) | The ARN of ECS execution role | `string` | n/a | yes |
-| <a name="input_ecs_security_group_ids"></a> [ecs\_security\_group\_ids](#input\_ecs\_security\_group\_ids) | The list of security group IDs to assign to the ECS task or service | `list` | n/a | yes |
-| <a name="input_ecs_subnet_ids"></a> [ecs\_subnet\_ids](#input\_ecs\_subnet\_ids) | The list of subnet IDs to assign to the ECS task or service | `list` | n/a | yes |
+| <a name="input_ecs_security_group_ids"></a> [ecs\_security\_group\_ids](#input\_ecs\_security\_group\_ids) | The list of security group IDs to assign to the ECS task or service | `list(string)` | n/a | yes |
+| <a name="input_ecs_subnet_ids"></a> [ecs\_subnet\_ids](#input\_ecs\_subnet\_ids) | The list of subnet IDs to assign to the ECS task or service | `list(string)` | n/a | yes |
 | <a name="input_ecs_task_role_arn"></a> [ecs\_task\_role\_arn](#input\_ecs\_task\_role\_arn) | The ARN of the ECS task role | `string` | n/a | yes |
 | <a name="input_lb_certificate_arn"></a> [lb\_certificate\_arn](#input\_lb\_certificate\_arn) | The ARN of the default SSL server certificate | `string` | n/a | yes |
-| <a name="input_lb_security_groups"></a> [lb\_security\_groups](#input\_lb\_security\_groups) | The list of security group IDs to assign to the LB | `list` | n/a | yes |
-| <a name="input_lb_subnets"></a> [lb\_subnets](#input\_lb\_subnets) | The list of subnet IDs to attach to the LB | `list` | n/a | yes |
+| <a name="input_lb_security_groups"></a> [lb\_security\_groups](#input\_lb\_security\_groups) | The list of security group IDs to assign to the LB | `list(string)` | n/a | yes |
+| <a name="input_lb_subnets"></a> [lb\_subnets](#input\_lb\_subnets) | The list of subnet IDs to attach to the LB | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
 | <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
 | <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | The number of days you want to retain log events | `number` | `90` | no |
@@ -106,6 +107,9 @@ module "redash" {
 | <a name="input_lb_access_log_prefix"></a> [lb\_access\_log\_prefix](#input\_lb\_access\_log\_prefix) | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
 | <a name="input_lb_ssl_policy"></a> [lb\_ssl\_policy](#input\_lb\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2016-08"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for the resource names | `string` | `null` | no |
+| <a name="input_scheduler_container_cpu"></a> [scheduler\_container\_cpu](#input\_scheduler\_container\_cpu) | The number of cpu units to reserve for the scheduler container | `number` | `1024` | no |
+| <a name="input_scheduler_container_memory"></a> [scheduler\_container\_memory](#input\_scheduler\_container\_memory) | The amount of memory (in MiB) to allow the scheduler container | `number` | `2048` | no |
+| <a name="input_scheduler_desired_count"></a> [scheduler\_desired\_count](#input\_scheduler\_desired\_count) | The number of redash scheduler tasks | `number` | `1` | no |
 | <a name="input_server_container_cpu"></a> [server\_container\_cpu](#input\_server\_container\_cpu) | The number of cpu units to reserve for the server container | `number` | `1024` | no |
 | <a name="input_server_container_memory"></a> [server\_container\_memory](#input\_server\_container\_memory) | The amount of memory (in MiB) to allow the server container | `number` | `2048` | no |
 | <a name="input_server_desired_count"></a> [server\_desired\_count](#input\_server\_desired\_count) | The number of redash server tasks | `number` | `1` | no |

--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -1,7 +1,7 @@
 # Server
 module "server_container_definitions" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.56.0"
+  version = "0.58.1"
 
   container_name   = local.container_names["server"]
   container_image  = var.container_image_url
@@ -28,7 +28,7 @@ module "server_container_definitions" {
 # Worker
 module "worker_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.56.0"
+  version = "0.58.1"
 
   container_name   = local.container_names["worker"]
   container_image  = var.container_image_url
@@ -53,7 +53,7 @@ module "worker_container_definition" {
 # DB Create
 module "db_create_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.56.0"
+  version = "0.58.1"
 
   container_name   = local.container_names["db_create"]
   container_image  = var.container_image_url
@@ -78,7 +78,7 @@ module "db_create_container_definition" {
 # DB Migrate
 module "db_migrate_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.56.0"
+  version = "0.58.1"
 
   container_name   = local.container_names["db_migrate"]
   container_image  = var.container_image_url
@@ -103,7 +103,7 @@ module "db_migrate_container_definition" {
 # DB Upgrade
 module "db_upgrade_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"
-  version = "0.56.0"
+  version = "0.58.1"
 
   container_name   = local.container_names["db_upgrade"]
   container_image  = var.container_image_url

--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -50,6 +50,32 @@ module "worker_container_definition" {
   }
 }
 
+# Scheduler
+module "scheduler_container_definition" {
+  count   = local.redash_major_version >= 10 ? 1 : 0
+  source  = "cloudposse/ecs-container-definition/aws"
+  version = "0.58.1"
+
+  container_name   = local.container_names["scheduler"]
+  container_image  = var.container_image_url
+  container_cpu    = var.scheduler_container_cpu
+  container_memory = var.scheduler_container_memory
+  command          = local.commands["scheduler"]
+  environment      = var.container_environments
+  secrets          = var.container_secrets
+
+  log_configuration = {
+    logDriver     = "awslogs"
+    secretOptions = null
+
+    options = {
+      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-group"         = aws_cloudwatch_log_group.logs["scheduler"].name
+      "awslogs-stream-prefix" = "scheduler"
+    }
+  }
+}
+
 # DB Create
 module "db_create_container_definition" {
   source  = "cloudposse/ecs-container-definition/aws"

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -44,11 +44,11 @@ resource "aws_ecs_service" "server" {
 ## Worker
 resource "aws_ecs_task_definition" "worker" {
   family                   = local.container_names["worker"]
-  container_definitions    = module.worker_container_definition.json_map_encoded_list
+  container_definitions    = local.redash_major_version >= 10 ? "[${module.worker_container_definition.json_map_encoded}, ${module.scheduler_container_definition[0].json_map_encoded}]" : module.worker_container_definition.json_map_encoded_list
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = var.worker_container_cpu
-  memory                   = var.worker_container_memory
+  cpu                      = local.redash_major_version >= 10 ? var.worker_container_cpu + var.scheduler_container_cpu : var.worker_container_cpu
+  memory                   = local.redash_major_version >= 10 ? var.worker_container_memory + var.scheduler_container_memory : var.worker_container_memory
   execution_role_arn       = var.ecs_execution_role_arn
   task_role_arn            = var.ecs_task_role_arn
 }

--- a/aws/redash/local_variables.tf
+++ b/aws/redash/local_variables.tf
@@ -1,17 +1,18 @@
 locals {
   base_name = var.prefix == null ? "redash" : "${var.prefix}-redash"
 
-  container_names = {
+  container_names = merge({
     server     = var.prefix == null ? "redash-server" : "${var.prefix}-redash-server"
     worker     = var.prefix == null ? "redash-worker" : "${var.prefix}-redash-worker"
     db_create  = var.prefix == null ? "redash-db-create" : "${var.prefix}-redash-db-create"
     db_migrate = var.prefix == null ? "redash-db-migrate" : "${var.prefix}-redash-db-migrate"
     db_upgrade = var.prefix == null ? "redash-db-upgrade" : "${var.prefix}-redash-db-upgrade"
-  }
+  }, local.redash_major_version >= 10 ? { scheduler = var.prefix == null ? "redash-scheduler" : "${var.prefix}-redash-scheduler" } : {})
 
   commands = {
     server     = ["server"]
-    worker     = ["scheduler"]
+    worker     = local.redash_major_version >= 10 ? ["worker"] : ["scheduler"]
+    scheduler  = ["scheduler"]
     db_create  = ["create_db"]
     db_migrate = ["manage", "db", "migrate"]
     db_upgrade = ["manage", "db", "upgrade"]
@@ -24,4 +25,6 @@ locals {
       hostPort      = 5000
     },
   ]
+
+  redash_major_version = split(".", split(":", var.container_image_url)[1])[0]
 }

--- a/aws/redash/main.tf
+++ b/aws/redash/main.tf
@@ -11,9 +11,9 @@
 *
 * ```hcl
 * module "redash" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v1.4.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/redash?ref=v3.4.0"
 *
-*   container_image_url = "redash/redash:8.0.2.b37747"
+*   container_image_url = "redash/redash:10.1.0.b50633"
 *
 *   container_environments = [
 *     {

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -102,6 +102,24 @@ variable "prefix" {
   default     = null
 }
 
+variable "scheduler_container_cpu" {
+  type        = number
+  default     = 1024
+  description = "The number of cpu units to reserve for the scheduler container"
+}
+
+variable "scheduler_container_memory" {
+  type        = number
+  default     = 2048
+  description = "The amount of memory (in MiB) to allow the scheduler container"
+}
+
+variable "scheduler_desired_count" {
+  type        = number
+  default     = 1
+  description = "The number of redash scheduler tasks"
+}
+
 variable "server_container_cpu" {
   type        = number
   default     = 1024


### PR DESCRIPTION
I have modified this module to allow to create Redash v10.

Please see [the third commit](https://github.com/elastic-infra/terraform-modules/pull/45/commits/c18fe8f5e5aba4e001703b688bc2ba0e5265ff83) for the main modifications, which are a bit complicated since this module can also create Redash before v9.

The Scheduler task, which was separated from the Worker task in Redash v10, works in the Worker's ECS Service.