### PR TITLE
Ignore changes `replication_configuration`

### DIFF
--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -282,6 +282,12 @@ resource "aws_s3_bucket" "b" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      replication_configuration,
+    ]
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "b" {


### PR DESCRIPTION
I would like to use this module to configure S3 replication.

We can configure the s3 replication in the following ways:

1. use the `replication_configuration` block in aws_s3_bucket resource
2. use the `aws_s3_bucket_replication_configuration` resource

SEE:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration

> The aws_s3_bucket_replication_configuration resource provides the following features that are not available in the aws_s3_bucket resource:

I think the latter is a better way because of the many settings that can be achieved. Thanks.