### PR TITLE
Constraints for terraform 1.1.X

### DIFF
--- a/aws/ei-base-role/README.md
+++ b/aws/ei-base-role/README.md
@@ -21,7 +21,7 @@ module "ei_base_role" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0, < 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0, < 1.2.0 |
 
 ## Providers
 

--- a/aws/ei-base-role/versions.tf
+++ b/aws/ei-base-role/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0, < 1.1.0"
+  required_version = ">= 0.12.0, < 1.2.0"
 }

--- a/aws/iam-service-role/README.md
+++ b/aws/iam-service-role/README.md
@@ -21,7 +21,7 @@ module "service_role" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6, < 0.16 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6, < 1.2.0 |
 
 ## Providers
 

--- a/aws/iam-service-role/versions.tf
+++ b/aws/iam-service-role/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.6, < 1.1.0"
+  required_version = ">= 0.12.6, < 1.2.0"
 }

--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -168,7 +168,7 @@ object_lock_configuration = [
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26, < 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26, < 1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0.0 |
 
 ## Providers

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14, < 1.1.0"
+  required_version = ">= 0.14, < 1.2.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -167,7 +167,7 @@
 */
 
 locals {
-  block_access_enabled = !var.disable_private
+  block_access_enabled = ! var.disable_private
   versioning_set       = (var.versioning != null ? [true] : [])
 }
 

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -46,7 +46,7 @@ module "redash" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 1.2.0 |
 
 ## Providers
 

--- a/aws/redash/versions.tf
+++ b/aws/redash/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.2, < 1.1.0"
+  required_version = ">= 0.12.2, < 1.2.0"
 }

--- a/aws/tools/Makefile
+++ b/aws/tools/Makefile
@@ -6,4 +6,4 @@ fmt:
 	terraform fmt
 
 docs:
-	docker run --rm -v $(shell pwd):/data cytopia/terraform-docs terraform-docs-replace-012 --sort-by-required markdown README.md
+	docker run --rm -v $(shell pwd):/data cytopia/terraform-docs terraform-docs-replace-012 --sort-by required markdown README.md


### PR DESCRIPTION
Already terraform 1.1.4 has been released.
We need to update the version constraints.