### PR TITLE
Set provider requirements to avoid warnings with newer provider

### DIFF
--- a/aws/alb-accesslog-table/README.md
+++ b/aws/alb-accesslog-table/README.md
@@ -20,12 +20,13 @@ module "main" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/alb-accesslog-table/constraints.tf
+++ b/aws/alb-accesslog-table/constraints.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/cloudfront-log-table/README.md
+++ b/aws/cloudfront-log-table/README.md
@@ -22,12 +22,13 @@ module "main" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/cloudfront-log-table/constraints.tf
+++ b/aws/cloudfront-log-table/constraints.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/ei-base-role/README.md
+++ b/aws/ei-base-role/README.md
@@ -22,12 +22,13 @@ module "ei_base_role" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.0, < 1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/ei-base-role/versions.tf
+++ b/aws/ei-base-role/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.12.0, < 1.2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -24,13 +24,14 @@ module "ei_privatelink_consumer" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/ei-privatelink-consumer/versions.tf
+++ b/aws/ei-privatelink-consumer/versions.tf
@@ -1,3 +1,9 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/iam-service-role/README.md
+++ b/aws/iam-service-role/README.md
@@ -22,12 +22,13 @@ module "service_role" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6, < 1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/iam-service-role/versions.tf
+++ b/aws/iam-service-role/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.12.6, < 1.2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/nlb-accesslog-table/README.md
+++ b/aws/nlb-accesslog-table/README.md
@@ -20,12 +20,13 @@ module "main" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/nlb-accesslog-table/constraints.tf
+++ b/aws/nlb-accesslog-table/constraints.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -46,13 +46,14 @@ module "redash" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.2, < 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13, < 1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/redash/versions.tf
+++ b/aws/redash/versions.tf
@@ -1,3 +1,9 @@
 terraform {
-  required_version = ">= 0.12.2, < 1.2.0"
+  required_version = ">= 0.13, < 1.2.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -38,18 +38,19 @@ module "peering_acceptance" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_accepter"></a> [accepter](#module\_accepter) | git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master |  |
+| <a name="module_accepter"></a> [accepter](#module\_accepter) | git::https://github.com/cloudposse/terraform-terraform-label.git | master |
 
 ## Resources
 

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -41,4 +41,10 @@ locals {
 
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -40,18 +40,19 @@ module "peering-request" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_requester"></a> [requester](#module\_requester) | git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master |  |
+| <a name="module_requester"></a> [requester](#module\_requester) | git::https://github.com/cloudposse/terraform-terraform-label.git | master |
 
 ## Resources
 

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -44,4 +44,10 @@ locals {
 
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }

--- a/aws/waf-log-table/README.md
+++ b/aws/waf-log-table/README.md
@@ -20,12 +20,13 @@ module "main" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
 
 ## Modules
 

--- a/aws/waf-log-table/constraints.tf
+++ b/aws/waf-log-table/constraints.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
 }


### PR DESCRIPTION
Add `required_providres`  blocks.
https://www.terraform.io/language/providers/requirements#v0-12-compatible-provider-requirements

This is to avoid warnings in module usage with non-default provider.

```
│ Warning: Provider aws is undefined
│ 
│   on service_vpc_use1.tf line 44, in module "peering_from_use1":
│   44:     aws = aws.us-east-1
│ 
│ Module module.peering_from_use1 does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers block within the module.
│ 
│ (and 2 more similar warnings elsewhere)
```

This feature is introduced in AWS provider 0.13. Some version constraints are changed.