### PR TITLE
Create an IAM role for Grafana

### DIFF
--- a/aws/grafana-role/README.md
+++ b/aws/grafana-role/README.md
@@ -44,11 +44,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_assumerole_principals"></a> [assumerole\_principals](#input\_assumerole\_principals) | List of principals to invoke assumerole | `list(string)` | <pre>[<br>  "arn:aws:iam::089928438340:role/eicommonprod-grafana-ec2"<br>]</pre> | no |
-| <a name="input_athena_result_bucket"></a> [athena\_result\_bucket](#input\_athena\_result\_bucket) | Bucket of Athena's result | `string` | `null` | no |
-| <a name="input_athena_search_buckets"></a> [athena\_search\_buckets](#input\_athena\_search\_buckets) | List of buckets searched by Athena | `list(string)` | `[]` | no |
-| <a name="input_athena_workgroups"></a> [athena\_workgroups](#input\_athena\_workgroups) | List of WorkGroups | `list(string)` | `[]` | no |
-| <a name="input_cwlogs_search_loggroups"></a> [cwlogs\_search\_loggroups](#input\_cwlogs\_search\_loggroups) | List of LogGroups searched by CloudWatch Logs Insight | `list(string)` | `[]` | no |
+| <a name="input_assumerole_principals"></a> [assumerole\_principals](#input\_assumerole\_principals) | ARN list of principals to invoke assumerole | `list(string)` | <pre>[<br>  "arn:aws:iam::089928438340:role/eicommonprod-grafana-ec2"<br>]</pre> | no |
+| <a name="input_athena_result_bucket"></a> [athena\_result\_bucket](#input\_athena\_result\_bucket) | Bucket ARN of Athena's result | `string` | `null` | no |
+| <a name="input_athena_search_buckets"></a> [athena\_search\_buckets](#input\_athena\_search\_buckets) | ARN list of buckets searched by Athena | `list(string)` | `[]` | no |
+| <a name="input_athena_workgroups"></a> [athena\_workgroups](#input\_athena\_workgroups) | ARN list of WorkGroups | `list(string)` | `[]` | no |
+| <a name="input_cwlogs_search_loggroups"></a> [cwlogs\_search\_loggroups](#input\_cwlogs\_search\_loggroups) | ARN list of LogGroups searched by CloudWatch Logs Insight | `list(string)` | `[]` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for all resources | `string` | `"ei"` | no |
 
 ## Outputs

--- a/aws/grafana-role/README.md
+++ b/aws/grafana-role/README.md
@@ -1,0 +1,61 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Grafana monitoring role
+
+### Usage
+
+```hcl
+module "grafana-role" {
+  source = "github.com/elastic-infra/terraform-modules//aws/grafana-role?ref=v4.2.0"
+
+  prefix                  = "prefix"
+  athena_workgroups       = [aws_athena_workgroup.infra.arn]
+  athena_result_bucket    = module.athena_bucket.bucket_arn
+  athena_search_buckets   = [module.log_bucket.bucket_arn]
+  cwlogs_search_loggroups = [data.aws_cloudwatch_log_group.rds_slowquery.arn]
+}
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy_document.grafana](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.grafana_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assumerole_principals"></a> [assumerole\_principals](#input\_assumerole\_principals) | List of principals to invoke assumerole | `list(string)` | <pre>[<br>  "arn:aws:iam::089928438340:role/eicommonprod-grafana-ec2"<br>]</pre> | no |
+| <a name="input_athena_result_bucket"></a> [athena\_result\_bucket](#input\_athena\_result\_bucket) | Bucket of Athena's result | `string` | `null` | no |
+| <a name="input_athena_search_buckets"></a> [athena\_search\_buckets](#input\_athena\_search\_buckets) | List of buckets searched by Athena | `list(string)` | `[]` | no |
+| <a name="input_athena_workgroups"></a> [athena\_workgroups](#input\_athena\_workgroups) | List of WorkGroups | `list(string)` | `[]` | no |
+| <a name="input_cwlogs_search_loggroups"></a> [cwlogs\_search\_loggroups](#input\_cwlogs\_search\_loggroups) | List of LogGroups searched by CloudWatch Logs Insight | `list(string)` | `[]` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for all resources | `string` | `"ei"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | Grafana monitoring role ARN |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Grafana monitoring role name |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/grafana-role/iam.tf
+++ b/aws/grafana-role/iam.tf
@@ -16,6 +16,68 @@ resource "aws_iam_role" "grafana" {
 }
 
 data "aws_iam_policy_document" "grafana" {
+  # CloudWatch
+  ## https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:ListMetrics",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:GetLogGroupFields",
+      "logs:GetQueryResults",
+    ]
+
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.cwlogs_search_loggroups == [] ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "logs:GetLogEvents",
+        "logs:StartQuery",
+        "logs:StopQuery",
+      ]
+
+      resources = var.cwlogs_search_loggroups
+    }
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "tag:GetResources",
+    ]
+
+    resources = ["*"]
+  }
+
   # Athena
   ## https://docs.aws.amazon.com/ja_jp/athena/latest/ug/example-policies-workgroup.html
   dynamic "statement" {

--- a/aws/grafana-role/iam.tf
+++ b/aws/grafana-role/iam.tf
@@ -1,0 +1,130 @@
+data "aws_iam_policy_document" "grafana_sts" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = var.assumerole_principals
+    }
+  }
+}
+
+resource "aws_iam_role" "grafana" {
+  name               = "${var.prefix}-grafana-role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.grafana_sts.json
+}
+
+data "aws_iam_policy_document" "grafana" {
+  # Athena
+  ## https://docs.aws.amazon.com/ja_jp/athena/latest/ug/example-policies-workgroup.html
+  dynamic "statement" {
+    for_each = var.athena_result_bucket == null ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "glue:List*",
+        "glue:Get*",
+      ]
+
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.athena_result_bucket == null ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "athena:ListEngineVersions",
+        "athena:ListWorkGroups",
+        "athena:ListDataCatalogs",
+        "athena:ListDatabases",
+        "athena:GetDatabase",
+        "athena:ListTableMetadata",
+        "athena:GetTableMetadata",
+      ]
+
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.athena_workgroups == [] ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "athena:GetWorkGroup",
+        "athena:BatchGetQueryExecution",
+        "athena:GetQueryExecution",
+        "athena:ListQueryExecutions",
+        "athena:StartQueryExecution",
+        "athena:StopQueryExecution",
+        "athena:GetQueryResults",
+        "athena:GetQueryResultsStream",
+        "athena:CreateNamedQuery",
+        "athena:GetNamedQuery",
+        "athena:BatchGetNamedQuery",
+        "athena:ListNamedQueries",
+        "athena:DeleteNamedQuery",
+        "athena:CreatePreparedStatement",
+        "athena:GetPreparedStatement",
+        "athena:ListPreparedStatements",
+        "athena:UpdatePreparedStatement",
+        "athena:DeletePreparedStatement",
+      ]
+
+      resources = var.athena_workgroups
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.athena_result_bucket == null ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "s3:List*",
+        "s3:Get*",
+        "s3:Put*",
+        "s3:AbortMultipartUpload",
+      ]
+
+      resources = [
+        var.athena_result_bucket,
+        "${var.athena_result_bucket}/*",
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.athena_search_buckets == [] ? [] : [1]
+
+    content {
+      effect = "Allow"
+
+      actions = [
+        "s3:ListBucket",
+        "s3:GetObject",
+      ]
+
+      resources = concat(
+        var.athena_search_buckets,
+        formatlist("%s/*", var.athena_search_buckets),
+      )
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "grafana" {
+  name   = "grafana"
+  role   = aws_iam_role.grafana.id
+  policy = data.aws_iam_policy_document.grafana.json
+}

--- a/aws/grafana-role/main.tf
+++ b/aws/grafana-role/main.tf
@@ -1,0 +1,20 @@
+/**
+* ## Information
+*
+* Grafana monitoring role
+*
+* ### Usage
+*
+* ```hcl
+* module "grafana-role" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/grafana-role?ref=v4.2.0"
+*
+*   prefix                  = "prefix"
+*   athena_workgroups       = [aws_athena_workgroup.infra.arn]
+*   athena_result_bucket    = module.athena_bucket.bucket_arn
+*   athena_search_buckets   = [module.log_bucket.bucket_arn]
+*   cwlogs_search_loggroups = [data.aws_cloudwatch_log_group.rds_slowquery.arn]
+* }
+* ```
+*
+*/

--- a/aws/grafana-role/output.tf
+++ b/aws/grafana-role/output.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  value       = aws_iam_role.grafana.arn
+  description = "Grafana monitoring role ARN"
+}
+
+output "role_name" {
+  value       = aws_iam_role.grafana.name
+  description = "Grafana monitoring role name"
+}

--- a/aws/grafana-role/variables.tf
+++ b/aws/grafana-role/variables.tf
@@ -27,3 +27,9 @@ variable "athena_search_buckets" {
   default     = []
   description = "List of buckets searched by Athena"
 }
+
+variable "cwlogs_search_loggroups" {
+  type        = list(string)
+  default     = []
+  description = "List of LogGroups searched by CloudWatch Logs Insight"
+}

--- a/aws/grafana-role/variables.tf
+++ b/aws/grafana-role/variables.tf
@@ -7,29 +7,29 @@ variable "prefix" {
 variable "assumerole_principals" {
   type        = list(string)
   default     = ["arn:aws:iam::089928438340:role/eicommonprod-grafana-ec2"]
-  description = "List of principals to invoke assumerole"
+  description = "ARN list of principals to invoke assumerole"
 }
 
 variable "athena_workgroups" {
   type        = list(string)
   default     = []
-  description = "List of WorkGroups"
+  description = "ARN list of WorkGroups"
 }
 
 variable "athena_result_bucket" {
   type        = string
   default     = null
-  description = "Bucket of Athena's result"
+  description = "Bucket ARN of Athena's result"
 }
 
 variable "athena_search_buckets" {
   type        = list(string)
   default     = []
-  description = "List of buckets searched by Athena"
+  description = "ARN list of buckets searched by Athena"
 }
 
 variable "cwlogs_search_loggroups" {
   type        = list(string)
   default     = []
-  description = "List of LogGroups searched by CloudWatch Logs Insight"
+  description = "ARN list of LogGroups searched by CloudWatch Logs Insight"
 }

--- a/aws/grafana-role/variables.tf
+++ b/aws/grafana-role/variables.tf
@@ -1,0 +1,29 @@
+variable "prefix" {
+  type        = string
+  default     = "ei"
+  description = "Prefix for all resources"
+}
+
+variable "assumerole_principals" {
+  type        = list(string)
+  default     = ["arn:aws:iam::089928438340:role/eicommonprod-grafana-ec2"]
+  description = "List of principals to invoke assumerole"
+}
+
+variable "athena_workgroups" {
+  type        = list(string)
+  default     = []
+  description = "List of WorkGroups"
+}
+
+variable "athena_result_bucket" {
+  type        = string
+  default     = null
+  description = "Bucket of Athena's result"
+}
+
+variable "athena_search_buckets" {
+  type        = list(string)
+  default     = []
+  description = "List of buckets searched by Athena"
+}


### PR DESCRIPTION
I added module that create IAM role for Grafana.

Create an IAM role with the following permissions.

- Athena : 15037a0b0ee1958d0230d53e9a7d1bb2201e4222
- CloudWatch Logs Insights : 27a41a4f857937a5ed704a7486fb53850c61352e

Use this IAM role with assumerole from `assumerole_principals` .