### PR TITLE
Add ei-cloudwatch-metric-stream module

### DIFF
--- a/aws/ei-cloudwatch-metric-stream/README.md
+++ b/aws/ei-cloudwatch-metric-stream/README.md
@@ -1,0 +1,65 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Elastic Infra - CloudWatch Metic Steam Resource
+
+### Usage
+
+```hcl
+module "ei_cloudwatch_metric_stream" {
+  source         = "github.com/elastic-infra/terraform-modules//aws/ei-privatelink-consumer?ref=vX.Y.Z"
+  ei_access_key  = "foo"
+  s3_bucket_name = "barprod-cw-metic-stream-backup"
+}
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cw_metric_stream_role"></a> [cw\_metric\_stream\_role](#module\_cw\_metric\_stream\_role) | ../iam-service-role | n/a |
+| <a name="module_kinesis_backup_bucket"></a> [kinesis\_backup\_bucket](#module\_kinesis\_backup\_bucket) | ../private-s3-bucket | n/a |
+| <a name="module_kinesis_role"></a> [kinesis\_role](#module\_kinesis\_role) | ../iam-service-role | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.kinesis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_stream.kinesis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_stream) | resource |
+| [aws_cloudwatch_metric_stream.to_ei](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_stream) | resource |
+| [aws_kinesis_firehose_delivery_stream.cw_metric_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
+| [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [aws_iam_policy_document.cw_metric_stream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kinesis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ei_access_key"></a> [ei\_access\_key](#input\_ei\_access\_key) | Access key for EI HTTP endpoint | `string` | n/a | yes |
+| <a name="input_ei_http_endpoint"></a> [ei\_http\_endpoint](#input\_ei\_http\_endpoint) | The HTTP endpoint URL to which Kinesis Firehose sends data | `string` | `"https://cw-metric-stream.elastic-infra.com/v1"` | no |
+| <a name="input_include_namespaces"></a> [include\_namespaces](#input\_include\_namespaces) | List of inclusive metric filters. See also https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html | `list(string)` | <pre>[<br>  "AWS/ELB",<br>  "AWS/RDS"<br>]</pre> | no |
+| <a name="input_kinesis_http_buffer_interval"></a> [kinesis\_http\_buffer\_interval](#input\_kinesis\_http\_buffer\_interval) | Buffer incoming data for the specified period of time, in seconds, before delivering it to HTTP endpoint. | `number` | `60` | no |
+| <a name="input_kinesis_http_buffer_size"></a> [kinesis\_http\_buffer\_size](#input\_kinesis\_http\_buffer\_size) | Buffer incoming data to the specified size, in MBs, before delivering it to HTTP endpoint. | `number` | `5` | no |
+| <a name="input_kinesis_retry_duration"></a> [kinesis\_retry\_duration](#input\_kinesis\_retry\_duration) | Total amount of seconds Firehose spends on retries. | `number` | `7200` | no |
+| <a name="input_kinesis_s3_buffer_interval"></a> [kinesis\_s3\_buffer\_interval](#input\_kinesis\_s3\_buffer\_interval) | Buffer incoming data for the specified period of time, in seconds, before delivering it to S3. | `number` | `300` | no |
+| <a name="input_kinesis_s3_buffer_size"></a> [kinesis\_s3\_buffer\_size](#input\_kinesis\_s3\_buffer\_size) | Buffer incoming data to the specified size, in MBs, before delivering it to S3. | `number` | `5` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Name of S3 bucket for Kinesis backup configuration | `string` | `"cw-metric-stream-backup"` | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/ei-cloudwatch-metric-stream/cloudwatch.tf
+++ b/aws/ei-cloudwatch-metric-stream/cloudwatch.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "cw_metric_stream" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "firehose:PutRecord",
+      "firehose:PutRecordBatch",
+    ]
+    resources = [
+      aws_kinesis_firehose_delivery_stream.cw_metric_stream.arn,
+    ]
+  }
+}
+
+module "cw_metric_stream_role" {
+  source = "../iam-service-role"
+
+  name = "cw-metric-stream-to-ei-${random_string.this.result}"
+  trusted_services = [
+    "streams.metrics.cloudwatch.amazonaws.com"
+  ]
+
+  role_inline_policies = [
+    {
+      name   = "SendToKinesis"
+      policy = data.aws_iam_policy_document.cw_metric_stream.json
+    },
+  ]
+}
+
+resource "aws_cloudwatch_metric_stream" "to_ei" {
+  name          = "to-ei-${random_string.this.result}"
+  role_arn      = module.cw_metric_stream_role.role_arn
+  firehose_arn  = aws_kinesis_firehose_delivery_stream.cw_metric_stream.arn
+  output_format = "json"
+
+  dynamic "include_filter" {
+    for_each = toset(var.include_namespaces)
+
+    content {
+      namespace = include_filter.value
+    }
+  }
+}

--- a/aws/ei-cloudwatch-metric-stream/kinesis.tf
+++ b/aws/ei-cloudwatch-metric-stream/kinesis.tf
@@ -1,0 +1,84 @@
+resource "aws_cloudwatch_log_group" "kinesis" {
+  name              = "/aws/firehose/cw-metric-stream-to-ei-${random_string.this.result}"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_stream" "kinesis" {
+  log_group_name = aws_cloudwatch_log_group.kinesis.name
+  name           = "to-ei"
+}
+
+data "aws_iam_policy_document" "kinesis" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+    resources = [
+      module.kinesis_backup_bucket.bucket_arn,
+      "${module.kinesis_backup_bucket.bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+    ]
+    resources = [
+      aws_cloudwatch_log_stream.kinesis.arn,
+    ]
+  }
+}
+
+module "kinesis_role" {
+  source = "../iam-service-role"
+
+  name = "kinesis-cw-metric-stream-to-ei-${random_string.this.result}"
+  trusted_services = [
+    "firehose.amazonaws.com"
+  ]
+
+  role_inline_policies = [
+    {
+      name   = "BackupToS3"
+      policy = data.aws_iam_policy_document.kinesis.json
+    },
+  ]
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "cw_metric_stream" {
+  name        = "cw-metric-stream-to-ei-${random_string.this.result}"
+  destination = "http_endpoint"
+
+  s3_configuration {
+    role_arn           = module.kinesis_role.role_arn
+    bucket_arn         = module.kinesis_backup_bucket.bucket_arn
+    buffer_size        = var.kinesis_s3_buffer_size
+    buffer_interval    = var.kinesis_s3_buffer_interval
+    compression_format = "GZIP"
+  }
+
+  http_endpoint_configuration {
+    url                = var.ei_http_endpoint
+    name               = "EI"
+    access_key         = var.ei_access_key
+    buffering_size     = var.kinesis_http_buffer_size
+    buffering_interval = var.kinesis_http_buffer_interval
+    role_arn           = module.kinesis_role.role_arn
+    s3_backup_mode     = "FailedDataOnly"
+    retry_duration     = var.kinesis_retry_duration
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.kinesis.name
+      log_stream_name = aws_cloudwatch_log_stream.kinesis.name
+    }
+  }
+}

--- a/aws/ei-cloudwatch-metric-stream/main.tf
+++ b/aws/ei-cloudwatch-metric-stream/main.tf
@@ -1,0 +1,21 @@
+/**
+* ## Information
+* 
+* Elastic Infra - CloudWatch Metic Steam Resource
+* 
+* ### Usage
+* 
+* ```hcl
+* module "ei_cloudwatch_metric_stream" {
+*   source         = "github.com/elastic-infra/terraform-modules//aws/ei-privatelink-consumer?ref=vX.Y.Z"
+*   ei_access_key  = "foo"
+*   s3_bucket_name = "barprod-cw-metic-stream-backup"
+* }
+* ```
+*/
+
+resource "random_string" "this" {
+  length  = 8
+  upper   = false
+  special = false
+}

--- a/aws/ei-cloudwatch-metric-stream/s3.tf
+++ b/aws/ei-cloudwatch-metric-stream/s3.tf
@@ -1,0 +1,25 @@
+module "kinesis_backup_bucket" {
+  source = "../private-s3-bucket"
+
+  bucket_name = "${var.s3_bucket_name}-${random_string.this.result}"
+
+  lifecycle_rule = [
+    {
+      id                                     = "all"
+      enabled                                = true
+      prefix                                 = null
+      abort_incomplete_multipart_upload_days = 3
+      tags                                   = {}
+      expiration = [
+        {
+          days                         = 14
+          date                         = null
+          expired_object_delete_marker = false
+        }
+      ]
+      transition                    = []
+      noncurrent_version_expiration = []
+      noncurrent_version_transition = []
+    }
+  ]
+}

--- a/aws/ei-cloudwatch-metric-stream/variables.tf
+++ b/aws/ei-cloudwatch-metric-stream/variables.tf
@@ -1,0 +1,52 @@
+variable "include_namespaces" {
+  type        = list(string)
+  description = "List of inclusive metric filters. See also https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html"
+  default     = ["AWS/ELB", "AWS/RDS"]
+}
+
+variable "ei_http_endpoint" {
+  type        = string
+  description = "The HTTP endpoint URL to which Kinesis Firehose sends data"
+  default     = "https://cw-metric-stream.elastic-infra.com/v1"
+}
+
+variable "ei_access_key" {
+  type        = string
+  description = "Access key for EI HTTP endpoint"
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "Name of S3 bucket for Kinesis backup configuration"
+  default     = "cw-metric-stream-backup"
+}
+
+variable "kinesis_s3_buffer_size" {
+  type        = number
+  description = "Buffer incoming data to the specified size, in MBs, before delivering it to S3."
+  default     = 5
+}
+
+variable "kinesis_s3_buffer_interval" {
+  type        = number
+  description = "Buffer incoming data for the specified period of time, in seconds, before delivering it to S3."
+  default     = 300
+}
+
+variable "kinesis_http_buffer_size" {
+  type        = number
+  description = "Buffer incoming data to the specified size, in MBs, before delivering it to HTTP endpoint."
+  default     = 5
+}
+
+variable "kinesis_http_buffer_interval" {
+  type        = number
+  description = "Buffer incoming data for the specified period of time, in seconds, before delivering it to HTTP endpoint."
+  default     = 60
+}
+
+variable "kinesis_retry_duration" {
+  type        = number
+  description = "Total amount of seconds Firehose spends on retries."
+  default     = 7200
+}


### PR DESCRIPTION
To send CloudWatch metrics to EI monitoring system with CloudWatch Metric Streams.