### PR TITLE
loosen constraints to use terraform 1.3.0 or later

### DIFF
--- a/aws/iam-service-role/versions.tf
+++ b/aws/iam-service-role/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6, < 1.3.0"
+  required_version = ">= 0.12.6"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
To use `iam-service-role` module in terraform 1.3.0 or later, I loosened the constraints.
I've confirmed that the latest version (1.3.5) of terraform works well.