### PR TITLE
 `private-s3-bucket` module support aws_s3_bucket_ownership_controls & set BucketOwnerEnforced by default

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -197,6 +197,7 @@ No modules.
 | [aws_s3_bucket_lifecycle_configuration.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_object_lock_configuration.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
+| [aws_s3_bucket_ownership_controls.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_public_access_block.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -214,6 +215,7 @@ No modules.
 | <a name="input_logging"></a> [logging](#input\_logging) | S3 access logging | <pre>list(object({<br>    target_bucket = string<br>    target_prefix = string<br>  }))</pre> | `[]` | no |
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | Enable MFA delete, this requires the versioning feature | `bool` | `false` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br>    rule = object({<br>      default_retention = object({<br>        mode  = string<br>        days  = number<br>        years = number<br>      })<br>    })<br>  }))</pre> | `[]` | no |
+| <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. | `string` | `null` | no |
 | <a name="input_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#input\_server\_side\_encryption\_configuration) | Server-side encryption configuration | <pre>list(object({<br>    rule = object({<br>      apply_server_side_encryption_by_default = object({<br>        sse_algorithm     = string<br>        kms_master_key_id = string<br>      })<br>    })<br>  }))</pre> | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | S3 object versioning settings | `bool` | `null` | no |

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -17,6 +17,7 @@ resource "aws_s3_bucket_logging" "b" {
 
 # grant
 resource "aws_s3_bucket_acl" "b" {
+  count  = local.object_ownership != "BucketOwnerEnforced" ? 1 : 0
   bucket = aws_s3_bucket.b.id
 
   acl = length(var.grant) > 0 ? null : "private"
@@ -49,6 +50,15 @@ resource "aws_s3_bucket_acl" "b" {
         id = data.aws_canonical_user_id.current.id
       }
     }
+  }
+}
+
+# Bucket Ownership Controls
+resource "aws_s3_bucket_ownership_controls" "b" {
+  bucket = aws_s3_bucket.b.id
+
+  rule {
+    object_ownership = local.object_ownership
   }
 }
 # lifecycle

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -176,7 +176,8 @@
 data "aws_canonical_user_id" "current" {}
 
 locals {
-  block_access_enabled = ! var.disable_private
+  block_access_enabled = !var.disable_private
+  object_ownership     = coalesce(var.object_ownership, length(var.grant) > 0 ? "ObjectWriter" : "BucketOwnerEnforced")
 }
 
 resource "aws_s3_bucket" "b" {

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -35,6 +35,12 @@ variable "logging" {
   default     = []
 }
 
+variable "object_ownership" {
+  type        = string
+  description = "Object ownership."
+  default     = null
+}
+
 variable "grant" {
   type = list(object({
     id          = string


### PR DESCRIPTION
S3 Bucket Ownership is set to AWS recommended `BucketOwnerEnforced` by default.
The ACL(include grant) cannot be set if `BucketOwnerEnforced` is set, so if there is a `grant` params, default to `ObjectWriter`.