### PR TITLE
loosen constraints of ei-base-role to use terraform 1.3.0 or later

### DIFF
--- a/aws/ei-base-role/versions.tf
+++ b/aws/ei-base-role/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 1.3.0"
+  required_version = ">= 0.12.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
For the same reason of https://github.com/elastic-infra/terraform-modules/pull/62, I loosened the constraints of `ei-base-role` module.