### PR TITLE
private-s3-bucket enable SSE−S3 by default

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -117,13 +117,13 @@ SSE-S3 is enabled by default. You need specify nothing.
 If you want to enable SSE-KMS, specify the KMS master key ID.
 
 ```hcl
-server_side_encryption_kms_master_key_id = "aws/s3" # or your CMK ID
+sse_kms_master_key_id = "aws/s3" # or your CMK ID
 ```
 
-If you want to disable server side encryption, set disable\_server\_side\_encryption as `true`.
+If you want to disable server side encryption, set disable\_sse as `true`.
 
 ```hcl
-disable_server_side_encryption = true
+disable_sse = true
 ```
 
 #### CORS headers
@@ -194,14 +194,14 @@ No modules.
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | S3 bucket name | `string` | n/a | yes |
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | S3 CORS headers | <pre>list(object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
 | <a name="input_disable_private"></a> [disable\_private](#input\_disable\_private) | If true, disable private bucket feature | `bool` | `false` | no |
-| <a name="input_disable_server_side_encryption"></a> [disable\_server\_side\_encryption](#input\_disable\_server\_side\_encryption) | If true, disable server side encryption | `bool` | `false` | no |
+| <a name="input_disable_sse"></a> [disable\_sse](#input\_disable\_sse) | If true, disable server side encryption | `bool` | `false` | no |
 | <a name="input_grant"></a> [grant](#input\_grant) | S3 grants | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | S3 lifecycle rule | <pre>list(object({<br>    id                                     = string<br>    enabled                                = bool<br>    prefix                                 = string<br>    abort_incomplete_multipart_upload_days = number<br>    tags                                   = map(string)<br>    transition = list(object({<br>      date          = string<br>      days          = number<br>      storage_class = string<br>    }))<br>    # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration<br>    # define as list for simplicity, though expected only a single object<br>    expiration = list(object({<br>      date                         = string<br>      days                         = number<br>      expired_object_delete_marker = bool<br>    }))<br>    noncurrent_version_transition = list(object({<br>      days          = number<br>      storage_class = string<br>    }))<br>    noncurrent_version_expiration = list(object({<br>      days = number<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | S3 access logging | <pre>list(object({<br>    target_bucket = string<br>    target_prefix = string<br>  }))</pre> | `[]` | no |
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | Enable MFA delete, this requires the versioning feature | `bool` | `false` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br>    rule = object({<br>      default_retention = object({<br>        mode  = string<br>        days  = number<br>        years = number<br>      })<br>    })<br>  }))</pre> | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. | `string` | `null` | no |
-| <a name="input_server_side_encryption_kms_master_key_id"></a> [server\_side\_encryption\_kms\_master\_key\_id](#input\_server\_side\_encryption\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `null` | no |
+| <a name="input_sse_kms_master_key_id"></a> [sse\_kms\_master\_key\_id](#input\_sse\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | S3 object versioning settings | `bool` | `null` | no |
 

--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -112,34 +112,18 @@ lifecycle_rule = [
 
 #### server\_side\_encryption\_configuration
 
-SSE-S3
+SSE-S3 is enabled by default. You need specify nothing.
+
+If you want to enable SSE-KMS, specify the KMS master key ID.
 
 ```hcl
-server_side_encryption_configuration = [
-  {
-    rule = {
-      apply_server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
-        kms_master_key_id = null
-      }
-    }
-  }
-]
+server_side_encryption_kms_master_key_id = "aws/s3" # or your CMK ID
 ```
 
-SSE-KMS
+If you want to disable server side encryption, set disable\_server\_side\_encryption as `true`.
 
 ```hcl
-server_side_encryption_configuration = [
-  {
-    rule = {
-      apply_server_side_encryption_by_default = {
-        sse_algorithm = "aws:kms"
-        kms_master_key_id = "aws/s3" # or your CMK ID
-      }
-    }
-  }
-]
+disable_server_side_encryption = true
 ```
 
 #### CORS headers
@@ -210,13 +194,14 @@ No modules.
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | S3 bucket name | `string` | n/a | yes |
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | S3 CORS headers | <pre>list(object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  }))</pre> | `[]` | no |
 | <a name="input_disable_private"></a> [disable\_private](#input\_disable\_private) | If true, disable private bucket feature | `bool` | `false` | no |
+| <a name="input_disable_server_side_encryption"></a> [disable\_server\_side\_encryption](#input\_disable\_server\_side\_encryption) | If true, disable server side encryption | `bool` | `false` | no |
 | <a name="input_grant"></a> [grant](#input\_grant) | S3 grants | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | S3 lifecycle rule | <pre>list(object({<br>    id                                     = string<br>    enabled                                = bool<br>    prefix                                 = string<br>    abort_incomplete_multipart_upload_days = number<br>    tags                                   = map(string)<br>    transition = list(object({<br>      date          = string<br>      days          = number<br>      storage_class = string<br>    }))<br>    # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration<br>    # define as list for simplicity, though expected only a single object<br>    expiration = list(object({<br>      date                         = string<br>      days                         = number<br>      expired_object_delete_marker = bool<br>    }))<br>    noncurrent_version_transition = list(object({<br>      days          = number<br>      storage_class = string<br>    }))<br>    noncurrent_version_expiration = list(object({<br>      days = number<br>    }))<br>  }))</pre> | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | S3 access logging | <pre>list(object({<br>    target_bucket = string<br>    target_prefix = string<br>  }))</pre> | `[]` | no |
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | Enable MFA delete, this requires the versioning feature | `bool` | `false` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br>    rule = object({<br>      default_retention = object({<br>        mode  = string<br>        days  = number<br>        years = number<br>      })<br>    })<br>  }))</pre> | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. | `string` | `null` | no |
-| <a name="input_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#input\_server\_side\_encryption\_configuration) | Server-side encryption configuration | <pre>list(object({<br>    rule = object({<br>      apply_server_side_encryption_by_default = object({<br>        sse_algorithm     = string<br>        kms_master_key_id = string<br>      })<br>    })<br>  }))</pre> | `[]` | no |
+| <a name="input_server_side_encryption_kms_master_key_id"></a> [server\_side\_encryption\_kms\_master\_key\_id](#input\_server\_side\_encryption\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | S3 object versioning settings | `bool` | `null` | no |
 

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -197,13 +197,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "b" {
 }
 # SSE
 resource "aws_s3_bucket_server_side_encryption_configuration" "b" {
-  count  = var.disable_server_side_encryption ? 0 : 1
+  count  = var.disable_sse ? 0 : 1
   bucket = aws_s3_bucket.b.id
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.server_side_encryption_kms_master_key_id
-      sse_algorithm     = var.server_side_encryption_kms_master_key_id == null ? "AES256" : "aws:kms"
+      kms_master_key_id = var.sse_kms_master_key_id
+      sse_algorithm     = var.sse_kms_master_key_id == null ? "AES256" : "aws:kms"
     }
   }
 }

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -197,13 +197,13 @@ resource "aws_s3_bucket_lifecycle_configuration" "b" {
 }
 # SSE
 resource "aws_s3_bucket_server_side_encryption_configuration" "b" {
-  count  = length(var.server_side_encryption_configuration) > 0 ? 1 : 0
+  count  = var.disable_server_side_encryption ? 0 : 1
   bucket = aws_s3_bucket.b.id
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = var.server_side_encryption_configuration[0].rule.apply_server_side_encryption_by_default.kms_master_key_id
-      sse_algorithm     = var.server_side_encryption_configuration[0].rule.apply_server_side_encryption_by_default.sse_algorithm
+      kms_master_key_id = var.server_side_encryption_kms_master_key_id
+      sse_algorithm     = var.server_side_encryption_kms_master_key_id == null ? "AES256" : "aws:kms"
     }
   }
 }

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -117,13 +117,13 @@
 * If you want to enable SSE-KMS, specify the KMS master key ID.
 *
 * ```hcl
-* server_side_encryption_kms_master_key_id = "aws/s3" # or your CMK ID
+* sse_kms_master_key_id = "aws/s3" # or your CMK ID
 * ```
 *
-* If you want to disable server side encryption, set disable_server_side_encryption as `true`.
+* If you want to disable server side encryption, set disable_sse as `true`.
 *
 * ```hcl
-* disable_server_side_encryption = true
+* disable_sse = true
 * ```
 *
 * #### CORS headers

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -112,34 +112,18 @@
 *
 * #### server_side_encryption_configuration
 *
-* SSE-S3
+* SSE-S3 is enabled by default. You need specify nothing.
+*
+* If you want to enable SSE-KMS, specify the KMS master key ID.
 *
 * ```hcl
-* server_side_encryption_configuration = [
-*   {
-*     rule = {
-*       apply_server_side_encryption_by_default = {
-*         sse_algorithm = "AES256"
-*         kms_master_key_id = null
-*       }
-*     }
-*   }
-* ]
+* server_side_encryption_kms_master_key_id = "aws/s3" # or your CMK ID
 * ```
 *
-* SSE-KMS
+* If you want to disable server side encryption, set disable_server_side_encryption as `true`.
 *
 * ```hcl
-* server_side_encryption_configuration = [
-*   {
-*     rule = {
-*       apply_server_side_encryption_by_default = {
-*         sse_algorithm = "aws:kms"
-*         kms_master_key_id = "aws/s3" # or your CMK ID
-*       }
-*     }
-*   }
-* ]
+* disable_server_side_encryption = true
 * ```
 *
 * #### CORS headers

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -83,13 +83,13 @@ variable "lifecycle_rule" {
   default     = []
 }
 
-variable "disable_server_side_encryption" {
+variable "disable_sse" {
   type        = bool
   description = "If true, disable server side encryption"
   default     = false
 }
 
-variable "server_side_encryption_kms_master_key_id" {
+variable "sse_kms_master_key_id" {
   type        = string
   description = "The AWS KMS master key ID used for the SSE-KMS encryption."
   default     = null

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -83,17 +83,16 @@ variable "lifecycle_rule" {
   default     = []
 }
 
-variable "server_side_encryption_configuration" {
-  type = list(object({
-    rule = object({
-      apply_server_side_encryption_by_default = object({
-        sse_algorithm     = string
-        kms_master_key_id = string
-      })
-    })
-  }))
-  description = "Server-side encryption configuration"
-  default     = []
+variable "disable_server_side_encryption" {
+  type        = bool
+  description = "If true, disable server side encryption"
+  default     = false
+}
+
+variable "server_side_encryption_kms_master_key_id" {
+  type        = string
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption."
+  default     = null
 }
 
 variable "cors_rule" {


### PR DESCRIPTION
I've fixed `private-s3-bucket` module to enable SSE−S3 by default.
In addition, I've also simplified the argument about server side encryption in cases of SSE-KMS. Now, in many case, we just specify a KMS master key ID only.

usage:
```hcl
# SSE−S3
module "example_bucket" {
  source = "source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vx.x.x"
}

# SSE−KMS
module "example_bucket" {
  source = "source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vx.x.x"
  sse_kms_master_key_id = aws_kms_key.s3.key_id # or "aws/s3"
}

# disable SSE
module "example_bucket" {
  source = "source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vx.x.x"
  disable_sse = true
}
```