### PR TITLE
Add cloudtrail log table

### DIFF
--- a/aws/cloudtrail-table/README.md
+++ b/aws/cloudtrail-table/README.md
@@ -1,0 +1,54 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for CloudTrail log
+
+### Usage
+
+```hcl
+module "main" {
+  source = "github.com/elastic-infra/terraform-modules//aws/cloudtrail-table?ref=v5.1.0"
+
+  name          = "main"
+  database_name = "cloudtrail"
+  location      = "s3://CloudTrail_bucket_name/AWSLogs/<ACCOUNT-ID>/CloudTrail/<REGION>"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_glue_catalog_table.t](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | The s3 location of the CloudTrail log. (ex: s3://CloudTrail\_bucket\_name/AWSLogs/<ACCOUNT-ID>/CloudTrail/<REGION>) | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_partition_range"></a> [partition\_range](#input\_partition\_range) | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/cloudtrail-table/constraints.tf
+++ b/aws/cloudtrail-table/constraints.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
+}

--- a/aws/cloudtrail-table/main.tf
+++ b/aws/cloudtrail-table/main.tf
@@ -1,0 +1,172 @@
+/**
+* ## Information
+*
+* Athena table for CloudTrail log
+*
+* ### Usage
+*
+* ```hcl
+* module "main" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/cloudtrail-table?ref=v5.1.0"
+*
+*   name          = "main"
+*   database_name = "cloudtrail"
+*   location      = "s3://CloudTrail_bucket_name/AWSLogs/<ACCOUNT-ID>/CloudTrail/<REGION>"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "com.amazon.emr.cloudtrail.CloudTrailInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hive.hcatalog.data.JsonSerDe"
+    }
+
+    columns {
+      name = "eventversion"
+      type = "string"
+    }
+
+    columns {
+      name = "useridentity"
+      type = "struct<type:string,principalId:string,arn:string,accountId:string,invokedBy:string,accessKeyId:string,userName:string,sessionContext:struct<attributes:struct<mfaAuthenticated:string,creationDate:string>,sessionIssuer:struct<type:string,principalId:string,arn:string,accountId:string,userName:string>,ec2RoleDelivery:string,webIdFederationData:map<string,string>>>"
+    }
+
+    columns {
+      name = "eventtime"
+      type = "string"
+    }
+
+    columns {
+      name = "eventsource"
+      type = "string"
+    }
+
+    columns {
+      name = "eventname"
+      type = "string"
+    }
+
+    columns {
+      name = "awsregion"
+      type = "string"
+    }
+
+    columns {
+      name = "sourceipaddress"
+      type = "string"
+    }
+
+    columns {
+      name = "useragent"
+      type = "string"
+    }
+
+    columns {
+      name = "errorcode"
+      type = "string"
+    }
+
+    columns {
+      name = "errormessage"
+      type = "string"
+    }
+
+    columns {
+      name = "requestparameters"
+      type = "string"
+    }
+
+    columns {
+      name = "responseelements"
+      type = "string"
+    }
+
+    columns {
+      name = "additionaleventdata"
+      type = "string"
+    }
+
+    columns {
+      name = "requestid"
+      type = "string"
+    }
+
+    columns {
+      name = "eventid"
+      type = "string"
+    }
+
+    columns {
+      name = "readonly"
+      type = "string"
+    }
+
+    columns {
+      name = "resources"
+      type = "array<struct<arn:string,accountId:string,type:string>>"
+    }
+
+    columns {
+      name = "eventtype"
+      type = "string"
+    }
+
+    columns {
+      name = "apiversion"
+      type = "string"
+    }
+
+    columns {
+      name = "recipientaccountid"
+      type = "string"
+    }
+
+    columns {
+      name = "serviceeventdetails"
+      type = "string"
+    }
+
+    columns {
+      name = "sharedeventid"
+      type = "string"
+    }
+
+    columns {
+      name = "vpcendpointid"
+      type = "string"
+    }
+
+    columns {
+      name = "tlsdetails"
+      type = "struct<tlsVersion:string,cipherSuite:string,clientProvidedHostHeader:string>"
+    }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+}

--- a/aws/cloudtrail-table/variables.tf
+++ b/aws/cloudtrail-table/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]+$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the CloudTrail log. (ex: s3://CloudTrail_bucket_name/AWSLogs/<ACCOUNT-ID>/CloudTrail/<REGION>)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}


### PR DESCRIPTION
Add new module creating the table for CloudTrail logs in Athena using partition projection.
The table schema was referenced from the below URL.
https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html#create-cloudtrail-table-partition-projection