### PR TITLE
Move to cloudposse/label/null

### DIFF
--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -50,7 +50,7 @@ module "peering_acceptance" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_accepter"></a> [accepter](#module\_accepter) | git::https://github.com/cloudposse/terraform-terraform-label.git | master |
+| <a name="module_accepter_label"></a> [accepter\_label](#module\_accepter\_label) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 

--- a/aws/vpc-peering-accepter-multiaccount/accepter.tf
+++ b/aws/vpc-peering-accepter-multiaccount/accepter.tf
@@ -3,9 +3,10 @@ locals {
   accepter_tags       = merge(var.tags, { "Side" = "accepter" })
 }
 
-module "accepter" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
-  enabled    = var.enabled
+module "accepter_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -55,7 +56,7 @@ locals {
 resource "aws_vpc_peering_connection_accepter" "accepter" {
   vpc_peering_connection_id = local.vpc_peering_connection_id
   auto_accept               = true
-  tags                      = module.accepter.tags
+  tags                      = module.accepter_label.tags
 }
 
 locals {

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -52,7 +52,7 @@ module "peering-request" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_requester"></a> [requester](#module\_requester) | git::https://github.com/cloudposse/terraform-terraform-label.git | master |
+| <a name="module_requester_label"></a> [requester\_label](#module\_requester\_label) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
 

--- a/aws/vpc-peering-requester-multiaccount/requester.tf
+++ b/aws/vpc-peering-requester-multiaccount/requester.tf
@@ -3,9 +3,10 @@ locals {
   requester_tags       = merge(var.tags, { "Side" = "requester" })
 }
 
-module "requester" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
-  enabled    = var.enabled
+module "requester_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -50,7 +51,7 @@ resource "aws_vpc_peering_connection" "requester" {
   peer_region   = var.peer_region
   auto_accept   = var.peering_auto_accept
 
-  tags = module.requester.tags
+  tags = module.requester_label.tags
 }
 
 locals {


### PR DESCRIPTION
The cloudposse/terraform-terraform-label module has been deprecated and will not be maintained.
=> https://github.com/cloudposse/terraform-terraform-label

I've move to the cloudposse/label/null module recommented by cloudposse.
( https://registry.terraform.io/modules/cloudposse/label/null/ )