### PR TITLE
Add mysql users module

### DIFF
--- a/mysql/users/README.md
+++ b/mysql/users/README.md
@@ -21,15 +21,15 @@ module "main_users" {
     user1 = {
       password = data.aws_kms_secrets.db_user.plaintext["user1"]
       privileges = {
-        "example" = ["ALL PRIVILEGES"]
-        "*"       = ["SESSION_VARIABLES_ADMIN"]
+        mysql_database.db.name = ["ALL PRIVILEGES"]
+        "*"                    = ["SESSION_VARIABLES_ADMIN"]
       }
       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
     }
     user2 = {
       password = data.aws_kms_secrets.db_user.plaintext["user2"]
       privileges = {
-        "example.table1" = ["SELECT"]
+        "${mysql_database.db.name}.table1" = ["SELECT"]
       }
     }
   }

--- a/mysql/users/README.md
+++ b/mysql/users/README.md
@@ -1,0 +1,82 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Create mysql users with grants
+
+### Usage
+
+```hcl
+resource "mysql_database" "db" {
+  provider = mysql.main
+
+  name                  = "example"
+  default_character_set = "utf8mb4"
+  default_collation     = "utf8mb4_general_ci"
+}
+
+module "main_users" {
+  source = "github.com/elastic-infra/terraform-modules//mysql/users?ref=v6.2.0"
+
+  users = {
+    user1 = {
+      password = data.aws_kms_secrets.db_user.plaintext["user1"]
+      privileges = {
+        "example" = ["ALL PRIVILEGES"]
+        "*"       = ["SESSION_VARIABLES_ADMIN"]
+      }
+      roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
+    }
+    user2 = {
+      password = data.aws_kms_secrets.db_user.plaintext["user2"]
+      privileges = {
+        "example.table1" = ["SELECT"]
+      }
+    }
+  }
+
+  providers = {
+    mysql = mysql.main
+  }
+}
+```
+
+* `password` - The password for the user.
+* `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
+* `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [mysql_grant.privileges](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/grant) | resource |
+| [mysql_grant.roles](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/grant) | resource |
+| [mysql_user.users](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/user) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br>    password   = string<br>    privileges = map(list(string))<br>    roles      = optional(list(string), [])<br>  }))</pre> | `{}` | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -1,0 +1,93 @@
+/**
+* ## Information
+*
+* Create mysql users with grants
+*
+* ### Usage
+*
+* ```hcl
+* resource "mysql_database" "db" {
+*   provider = mysql.main
+*
+*   name                  = "example"
+*   default_character_set = "utf8mb4"
+*   default_collation     = "utf8mb4_general_ci"
+* }
+*
+* module "main_users" {
+*   source = "github.com/elastic-infra/terraform-modules//mysql/users?ref=v6.2.0"
+*
+*   users = {
+*     user1 = {
+*       password = data.aws_kms_secrets.db_user.plaintext["user1"]
+*       privileges = {
+*         "example" = ["ALL PRIVILEGES"]
+*         "*"       = ["SESSION_VARIABLES_ADMIN"]
+*       }
+*       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
+*     }
+*     user2 = {
+*       password = data.aws_kms_secrets.db_user.plaintext["user2"]
+*       privileges = {
+*         "example.table1" = ["SELECT"]
+*       }
+*     }
+*   }
+*
+*   providers = {
+*     mysql = mysql.main
+*   }
+* }
+* ```
+*
+* * `password` - The password for the user.
+* * `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
+* * `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
+*/
+
+resource "mysql_user" "users" {
+  for_each = var.users
+
+  user               = each.key
+  host               = "%"
+  plaintext_password = each.value["password"]
+}
+
+locals {
+  privileges = {
+    for h in flatten([
+      for k, v in var.users : [
+        for target, priv in v["privileges"] : {
+          key        = "${k}.${target}"
+          user       = k
+          database   = length(split(".", target)) == 1 ? target : split(".", target)[0]
+          table      = length(split(".", target)) == 1 ? "*" : split(".", target)[1]
+          privileges = priv
+        }
+      ]
+    ]) : h["key"] => h
+  }
+  roles = {
+    for k, v in var.users :
+    k => v["roles"] if length(v["roles"]) > 0
+  }
+}
+
+resource "mysql_grant" "privileges" {
+  for_each = local.privileges
+
+  user       = mysql_user.users[each.value["user"]].user
+  host       = mysql_user.users[each.value["user"]].host
+  database   = each.value["database"]
+  table      = each.value["table"]
+  privileges = each.value["privileges"]
+}
+
+resource "mysql_grant" "roles" {
+  for_each = local.roles
+
+  user     = mysql_user.users[each.key].user
+  host     = mysql_user.users[each.key].host
+  database = ""
+  roles    = each.value
+}

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -21,15 +21,15 @@
 *     user1 = {
 *       password = data.aws_kms_secrets.db_user.plaintext["user1"]
 *       privileges = {
-*         "example" = ["ALL PRIVILEGES"]
-*         "*"       = ["SESSION_VARIABLES_ADMIN"]
+*         mysql_database.db.name = ["ALL PRIVILEGES"]
+*         "*"                    = ["SESSION_VARIABLES_ADMIN"]
 *       }
 *       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
 *     }
 *     user2 = {
 *       password = data.aws_kms_secrets.db_user.plaintext["user2"]
 *       privileges = {
-*         "example.table1" = ["SELECT"]
+*         "${mysql_database.db.name}.table1" = ["SELECT"]
 *       }
 *     }
 *   }

--- a/mysql/users/variables.tf
+++ b/mysql/users/variables.tf
@@ -1,0 +1,9 @@
+variable "users" {
+  description = "Specify mysql users and grants. The key is the user name, and value is the password and grants."
+  type = map(object({
+    password   = string
+    privileges = map(list(string))
+    roles      = optional(list(string), [])
+  }))
+  default = {}
+}

--- a/mysql/users/versions.tf
+++ b/mysql/users/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    mysql = {
+      source  = "petoju/mysql"
+      version = ">= 3"
+    }
+  }
+}


### PR DESCRIPTION
Add the module to create MySQL users.

```hcl
resource "mysql_database" "db" {
  provider = mysql.main
  name                  = "example"
  default_character_set = "utf8mb4"
  default_collation     = "utf8mb4_general_ci"
}

module "main_users" {
  source = "github.com/elastic-infra/terraform-modules//mysql/users?ref=v6.2.0"
  users = {
    user1 = {
      password = data.aws_kms_secrets.db_user.plaintext["user1"]
      privileges = {
        "example" = ["ALL PRIVILEGES"]
        "*"       = ["SESSION_VARIABLES_ADMIN"]
      }
      roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
    }
    user2 = {
      password = data.aws_kms_secrets.db_user.plaintext["user2"]
      privileges = {
        "example.table1" = ["SELECT"]
      }
    }
  }

  providers = {
    mysql = mysql.main
  }
}
```

* `password` - The password for the user.
* `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
* `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.