### PR TITLE
make cloudfront-log-table to support projection partition

### DIFF
--- a/aws/cloudfront-log-table/README.md
+++ b/aws/cloudfront-log-table/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The s3 location of the CloudFront log. (ex: s3://cloudfront-log/main) | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_partition_range"></a> [partition\_range](#input\_partition\_range) | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
 
 ## Outputs
 

--- a/aws/cloudfront-log-table/README.md
+++ b/aws/cloudfront-log-table/README.md
@@ -3,17 +3,46 @@
 
 Athena table for CloudFront log
 
-Notice: This module does not support partitioning.
+To use this module, the following application must be deployed and CloudFront logs must be partitioned.
+
+https://serverlessrepo.aws.amazon.com/applications/ap-northeast-1/089928438340/cloudfront-log-partition
 
 ### Usage
 
 ```hcl
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "cloudfront_log_partition" {
+  name             = "cloudfront-log-partition"
+  application_id   = "arn:aws:serverlessrepo:ap-northeast-1:089928438340:applications/cloudfront-log-partition"
+  semantic_version = "1.1.0"
+
+  parameters = {
+    SourceBucket         = "cloudfront-log"
+    DestinationBucket    = "cloudfront-log"
+    DestinationKeyPrefix = "partitioned/"
+  }
+
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_RESOURCE_POLICY",
+  ]
+}
+
+resource "aws_s3_bucket_notification" "log" {
+  bucket = "cloudfront-log"
+
+  lambda_function {
+    lambda_function_arn = aws_serverlessapplicationrepository_cloudformation_stack.cloudfront_log_partition.outputs["FunctionArn"]
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "main/"
+  }
+}
+
 module "main" {
-  source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-log-table?ref=v2.7.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-log-table?ref=v6.3.0"
 
   name          = "main"
   database_name = "cflog"
-  location      = "s3://cloudfront-log/main"
+  location      = "s3://cloudfront-log/partitioned/main"
 }
 ```
 

--- a/aws/cloudfront-log-table/main.tf
+++ b/aws/cloudfront-log-table/main.tf
@@ -3,17 +3,46 @@
 *
 * Athena table for CloudFront log
 *
-* Notice: This module does not support partitioning.
+* To use this module, the following application must be deployed and CloudFront logs must be partitioned.
+*
+* https://serverlessrepo.aws.amazon.com/applications/ap-northeast-1/089928438340/cloudfront-log-partition
 *
 * ### Usage
 *
 * ```hcl
+* resource "aws_serverlessapplicationrepository_cloudformation_stack" "cloudfront_log_partition" {
+*   name             = "cloudfront-log-partition"
+*   application_id   = "arn:aws:serverlessrepo:ap-northeast-1:089928438340:applications/cloudfront-log-partition"
+*   semantic_version = "1.1.0"
+*
+*   parameters = {
+*     SourceBucket         = "cloudfront-log"
+*     DestinationBucket    = "cloudfront-log"
+*     DestinationKeyPrefix = "partitioned/"
+*   }
+*
+*   capabilities = [
+*     "CAPABILITY_IAM",
+*     "CAPABILITY_RESOURCE_POLICY",
+*   ]
+* }
+*
+* resource "aws_s3_bucket_notification" "log" {
+*   bucket = "cloudfront-log"
+*
+*   lambda_function {
+*     lambda_function_arn = aws_serverlessapplicationrepository_cloudformation_stack.cloudfront_log_partition.outputs["FunctionArn"]
+*     events              = ["s3:ObjectCreated:*"]
+*     filter_prefix       = "main/"
+*   }
+* }
+*
 * module "main" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-log-table?ref=v2.7.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-log-table?ref=v6.3.0"
 *
 *   name          = "main"
 *   database_name = "cflog"
-*   location      = "s3://cloudfront-log/main"
+*   location      = "s3://cloudfront-log/partitioned/main"
 * }
 * ```
 *

--- a/aws/cloudfront-log-table/main.tf
+++ b/aws/cloudfront-log-table/main.tf
@@ -30,6 +30,14 @@ resource "aws_glue_catalog_table" "t" {
 
     # CloudFront log has two lines header
     "skip.header.line.count" = 2
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
   }
 
   storage_descriptor {
@@ -47,7 +55,7 @@ resource "aws_glue_catalog_table" "t" {
 
     # NOTE: https://docs.aws.amazon.com/athena/latest/ug/cloudfront-logs.html
     columns {
-      name = "date"
+      name = "log_date"
       type = "date"
     }
 
@@ -210,5 +218,10 @@ resource "aws_glue_catalog_table" "t" {
       name = "sc_range_end"
       type = "bigint"
     }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
   }
 }

--- a/aws/cloudfront-log-table/variables.tf
+++ b/aws/cloudfront-log-table/variables.tf
@@ -22,3 +22,9 @@ variable "location" {
   type        = string
   description = "The s3 location of the CloudFront log. (ex: s3://cloudfront-log/main)"
 }
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}


### PR DESCRIPTION
To use this module, the following application must be deployed and CloudFront logs must be partitioned.
https://serverlessrepo.aws.amazon.com/applications/ap-northeast-1/089928438340/cloudfront-log-partition