### PR TITLE
Simplify `private-s3-bucket` lifecycle arguments

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -62,7 +62,7 @@ logging = [
 Full featured example.
 
 NOTE:
-  * abort\_incomplete\_multipart\_upload\_days is exclusive against tags
+  * abort\_incomplete\_multipart\_upload\_days is always set as 3 days
   * expiration, noncurrent\_version\_{transition,expiration} can be set up to once
 
 ```hcl
@@ -75,7 +75,6 @@ lifecycle_rule = [
       a = "b"
       c = "d"
     }
-    abort_incomplete_multipart_upload_days = null
     transition = [
       {
         date          = null
@@ -198,7 +197,7 @@ No modules.
 | <a name="input_disable_private"></a> [disable\_private](#input\_disable\_private) | If true, disable private bucket feature | `bool` | `false` | no |
 | <a name="input_disable_sse"></a> [disable\_sse](#input\_disable\_sse) | If true, disable server side encryption | `bool` | `false` | no |
 | <a name="input_grant"></a> [grant](#input\_grant) | S3 grants | <pre>list(object({<br>    id          = string<br>    type        = string<br>    permissions = list(string)<br>    uri         = string<br>  }))</pre> | `[]` | no |
-| <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | S3 lifecycle rule | <pre>list(object({<br>    id                                     = string<br>    enabled                                = bool<br>    prefix                                 = string<br>    abort_incomplete_multipart_upload_days = number<br>    tags                                   = map(string)<br>    transition = list(object({<br>      date          = optional(string)<br>      days          = optional(number)<br>      storage_class = string<br>    }))<br>    # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration<br>    # define as list for simplicity, though expected only a single object<br>    expiration = list(object({<br>      date                         = optional(string)<br>      days                         = optional(number)<br>      expired_object_delete_marker = optional(bool, false)<br>    }))<br>    noncurrent_version_transition = list(object({<br>      days          = number<br>      versions      = optional(number)<br>      storage_class = string<br>    }))<br>    noncurrent_version_expiration = list(object({<br>      days     = number<br>      versions = optional(number)<br>    }))<br>  }))</pre> | `[]` | no |
+| <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | S3 lifecycle rule | <pre>list(object({<br>    id      = string<br>    enabled = optional(bool, true)<br>    prefix  = optional(string)<br>    tags    = optional(map(string), {})<br>    transition = optional(list(object({<br>      date          = optional(string)<br>      days          = optional(number)<br>      storage_class = string<br>    })), [])<br>    # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration<br>    # define as list for simplicity, though expected only a single object<br>    expiration = optional(list(object({<br>      date                         = optional(string)<br>      days                         = optional(number)<br>      expired_object_delete_marker = optional(bool, false)<br>    })), [])<br>    noncurrent_version_transition = optional(list(object({<br>      days          = number<br>      versions      = optional(number)<br>      storage_class = string<br>    })), [])<br>    noncurrent_version_expiration = optional(list(object({<br>      days     = number<br>      versions = optional(number)<br>    })), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | S3 access logging | <pre>list(object({<br>    target_bucket = string<br>    target_prefix = string<br>  }))</pre> | `[]` | no |
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | Enable MFA delete, this requires the versioning feature | `bool` | `false` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br>    rule = object({<br>      default_retention = object({<br>        mode  = string<br>        days  = number<br>        years = number<br>      })<br>    })<br>  }))</pre> | `[]` | no |

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -61,79 +61,22 @@ resource "aws_s3_bucket_ownership_controls" "b" {
     object_ownership = local.object_ownership
   }
 }
+
 # lifecycle
 resource "aws_s3_bucket_lifecycle_configuration" "b" {
-  count  = length(var.lifecycle_rule) > 0 ? 1 : 0
   bucket = aws_s3_bucket.b.id
 
-  # First(0-th) rule: aws_s3_bucket_lifecycle_configuration must have at least 1 rule block explicitly
   rule {
-    id     = var.lifecycle_rule[0].id
-    status = var.lifecycle_rule[0].enabled ? "Enabled" : "Disabled"
-    dynamic "filter" {
-      for_each = var.lifecycle_rule[0].prefix != null || length(var.lifecycle_rule[0].tags) > 0 ? [1] : []
-      content {
-        # Only prefix or only 1 tag: bare
-        # both prefix and tag, multiple tags: inside `and` block
-        prefix = length(var.lifecycle_rule[0].tags) == 0 ? var.lifecycle_rule[0].prefix : null
-        dynamic "tag" {
-          for_each = var.lifecycle_rule[0].prefix == null && length(var.lifecycle_rule[0].tags) == 1 ? [1] : []
-          content {
-            key   = keys(var.lifecycle_rule[0].tags)[0]
-            value = values(var.lifecycle_rule[0].tags)[0]
-          }
-        }
-        dynamic "and" {
-          for_each = (var.lifecycle_rule[0].prefix != null && length(var.lifecycle_rule[0].tags) >= 1) || length(var.lifecycle_rule[0].tags) >= 2 ? [1] : []
-          content {
-            prefix = var.lifecycle_rule[0].prefix
-            tags   = var.lifecycle_rule[0].tags
-          }
-        }
-      }
-    }
-    dynamic "abort_incomplete_multipart_upload" {
-      for_each = var.lifecycle_rule[0].abort_incomplete_multipart_upload_days != null ? [1] : []
-      content {
-        days_after_initiation = var.lifecycle_rule[0].abort_incomplete_multipart_upload_days
-      }
-    }
-    dynamic "transition" {
-      for_each = var.lifecycle_rule[0].transition
-      content {
-        date          = transition.value.date
-        days          = transition.value.days
-        storage_class = transition.value.storage_class
-      }
-    }
-    dynamic "expiration" {
-      for_each = var.lifecycle_rule[0].expiration
-      content {
-        date                         = expiration.value.date
-        days                         = expiration.value.days
-        expired_object_delete_marker = expiration.value.expired_object_delete_marker
-      }
-    }
-    dynamic "noncurrent_version_transition" {
-      for_each = var.lifecycle_rule[0].noncurrent_version_transition
-      content {
-        noncurrent_days           = noncurrent_version_transition.value.days
-        newer_noncurrent_versions = noncurrent_version_transition.value.versions
-        storage_class             = noncurrent_version_transition.value.storage_class
-      }
-    }
-    dynamic "noncurrent_version_expiration" {
-      for_each = var.lifecycle_rule[0].noncurrent_version_expiration
-      content {
-        noncurrent_days           = noncurrent_version_expiration.value.days
-        newer_noncurrent_versions = noncurrent_version_expiration.value.versions
-      }
+    id     = "Abort incomplete multipart upload"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 3
     }
   }
 
-  # Rest (1st and after) rules
   dynamic "rule" {
-    for_each = toset(slice(var.lifecycle_rule, 1, length(var.lifecycle_rule)))
+    for_each = toset(var.lifecycle_rule)
     content {
       id     = rule.value.id
       status = rule.value.enabled ? "Enabled" : "Disabled"
@@ -157,12 +100,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "b" {
               tags   = rule.value.tags
             }
           }
-        }
-      }
-      dynamic "abort_incomplete_multipart_upload" {
-        for_each = rule.value.abort_incomplete_multipart_upload_days != null ? [1] : []
-        content {
-          days_after_initiation = rule.value.abort_incomplete_multipart_upload_days
         }
       }
       dynamic "transition" {

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -62,7 +62,7 @@
 * Full featured example.
 *
 * NOTE:
-*   * abort_incomplete_multipart_upload_days is exclusive against tags
+*   * abort_incomplete_multipart_upload_days is always set as 3 days
 *   * expiration, noncurrent_version_{transition,expiration} can be set up to once
 *
 * ```hcl
@@ -75,7 +75,6 @@
 *       a = "b"
 *       c = "d"
 *     }
-*     abort_incomplete_multipart_upload_days = null
 *     transition = [
 *       {
 *         date          = null

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -54,32 +54,31 @@ variable "grant" {
 
 variable "lifecycle_rule" {
   type = list(object({
-    id                                     = string
-    enabled                                = bool
-    prefix                                 = string
-    abort_incomplete_multipart_upload_days = number
-    tags                                   = map(string)
-    transition = list(object({
+    id      = string
+    enabled = optional(bool, true)
+    prefix  = optional(string)
+    tags    = optional(map(string), {})
+    transition = optional(list(object({
       date          = optional(string)
       days          = optional(number)
       storage_class = string
-    }))
+    })), [])
     # Note for expiration, noncurrent_version_transition, noncurrent_version_expiration
     # define as list for simplicity, though expected only a single object
-    expiration = list(object({
+    expiration = optional(list(object({
       date                         = optional(string)
       days                         = optional(number)
       expired_object_delete_marker = optional(bool, false)
-    }))
-    noncurrent_version_transition = list(object({
+    })), [])
+    noncurrent_version_transition = optional(list(object({
       days          = number
       versions      = optional(number)
       storage_class = string
-    }))
-    noncurrent_version_expiration = list(object({
+    })), [])
+    noncurrent_version_expiration = optional(list(object({
       days     = number
       versions = optional(number)
-    }))
+    })), [])
   }))
   description = "S3 lifecycle rule"
   default     = []


### PR DESCRIPTION
I've fixed `private-s3-bucket` module to simplify its lifecycle arguments by:

- set AbortIncompleteMultipartUpload action as first rule and remove `abort_incomplete_multipart_upload_days` argument.
- set default value of some arguments by using `optional` method.