### PR TITLE
Fixed that `newer_noncurrent_versions` was not passed

### DIFF
--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -121,14 +121,16 @@ resource "aws_s3_bucket_lifecycle_configuration" "b" {
       dynamic "noncurrent_version_transition" {
         for_each = rule.value.noncurrent_version_transition
         content {
-          noncurrent_days = noncurrent_version_transition.value.days
-          storage_class   = noncurrent_version_transition.value.storage_class
+          newer_noncurrent_versions = noncurrent_version_transition.value.versions
+          noncurrent_days           = noncurrent_version_transition.value.days
+          storage_class             = noncurrent_version_transition.value.storage_class
         }
       }
       dynamic "noncurrent_version_expiration" {
         for_each = rule.value.noncurrent_version_expiration
         content {
-          noncurrent_days = noncurrent_version_expiration.value.days
+          newer_noncurrent_versions = noncurrent_version_expiration.value.versions
+          noncurrent_days           = noncurrent_version_expiration.value.days
         }
       }
     }


### PR DESCRIPTION
I noticed that no value was being passed to `newer_noncurrent_versions`, so I'll fix that.
