### PR TITLE
mysql/users module supports default role and TLS option

### DIFF
--- a/mysql/users/README.md
+++ b/mysql/users/README.md
@@ -65,6 +65,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [mysql_default_roles.default_roles](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/default_roles) | resource |
 | [mysql_grant.privileges](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/grant) | resource |
 | [mysql_grant.roles](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/grant) | resource |
 | [mysql_user.users](https://registry.terraform.io/providers/petoju/mysql/latest/docs/resources/user) | resource |
@@ -73,7 +74,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br>    host       = optional(string, "%")<br>    password   = string<br>    privileges = map(list(string))<br>    roles      = optional(list(string), [])<br>  }))</pre> | `{}` | no |
+| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br>    host          = optional(string, "%")<br>    password      = string<br>    tls_option    = optional(string)<br>    privileges    = map(list(string))<br>    roles         = optional(list(string), [])<br>    default_roles = optional(list(string), [])<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -71,6 +71,10 @@ locals {
     for k, v in var.users :
     k => v["roles"] if length(v["roles"]) > 0
   }
+  default_roles = {
+    for k, v in var.users :
+    k => v["default_roles"] if length(v["default_roles"]) > 0
+  }
 }
 
 resource "mysql_grant" "privileges" {
@@ -90,4 +94,12 @@ resource "mysql_grant" "roles" {
   host     = mysql_user.users[each.key].host
   database = ""
   roles    = each.value
+}
+
+resource "mysql_default_roles" "default_roles" {
+  for_each = local.default_roles
+
+  user  = mysql_user.users[each.key].user
+  host  = mysql_user.users[each.key].host
+  roles = each.value
 }

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -51,6 +51,7 @@ resource "mysql_user" "users" {
   user               = each.key
   host               = each.value["host"]
   plaintext_password = each.value["password"]
+  tls_option         = each.value["tls_option"]
 }
 
 locals {

--- a/mysql/users/variables.tf
+++ b/mysql/users/variables.tf
@@ -3,6 +3,7 @@ variable "users" {
   type = map(object({
     host          = optional(string, "%")
     password      = string
+    tls_option    = optional(string)
     privileges    = map(list(string))
     roles         = optional(list(string), [])
     default_roles = optional(list(string), [])

--- a/mysql/users/variables.tf
+++ b/mysql/users/variables.tf
@@ -1,10 +1,11 @@
 variable "users" {
   description = "Specify mysql users and grants. The key is the user name, and value is the password and grants."
   type = map(object({
-    host       = optional(string, "%")
-    password   = string
-    privileges = map(list(string))
-    roles      = optional(list(string), [])
+    host          = optional(string, "%")
+    password      = string
+    privileges    = map(list(string))
+    roles         = optional(list(string), [])
+    default_roles = optional(list(string), [])
   }))
   default = {}
 }


### PR DESCRIPTION
As the title suggests, the mysql/users module has been modified to support default roles and TLS option.