### PR TITLE
Enable tags to be added from outside the module

### DIFF
--- a/aws/iam-service-role/README.md
+++ b/aws/iam-service-role/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
 | <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
 | <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | STS ExternalId condition values to use with a role | `list(string)` | `[]` | no |
+| <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | Tags for IAM Role | `map(string)` | `{}` | no |
 | <a name="input_trusted_services"></a> [trusted\_services](#input\_trusted\_services) | AWS Services that can assume these roles | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/aws/iam-service-role/main.tf
+++ b/aws/iam-service-role/main.tf
@@ -46,6 +46,8 @@ resource "aws_iam_role" "this" {
   path               = var.role_path
   description        = var.role_description
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
+
+  tags = var.role_tags
 }
 
 resource "aws_iam_role_policy_attachment" "this" {

--- a/aws/iam-service-role/variables.tf
+++ b/aws/iam-service-role/variables.tf
@@ -47,3 +47,9 @@ variable "role_sts_externalid" {
   type        = list(string)
   default     = []
 }
+
+variable "role_tags" {
+  description = "Tags for IAM Role"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Make it possible to add tags to roles from outside the module.