### PR TITLE
Fix VPC flow log column types

### DIFF
--- a/aws/flow-log-table/const.tf
+++ b/aws/flow-log-table/const.tf
@@ -14,7 +14,7 @@ locals {
     v2 = [
       {
         name = "version"
-        type = "string"
+        type = "int"
       },
       {
         name = "account_id"
@@ -42,7 +42,7 @@ locals {
       },
       {
         name = "protocol"
-        type = "bigint"
+        type = "int"
       },
       {
         name = "packets"
@@ -88,7 +88,7 @@ locals {
       },
       {
         name = "type"
-        type = "int"
+        type = "string"
       },
       {
         name = "pkt_srcaddr"
@@ -132,7 +132,7 @@ locals {
       },
       {
         name = "traffic_path"
-        type = "string"
+        type = "int"
       },
     ]
     v7 = [


### PR DESCRIPTION
Fix column types to match the documentation
https://docs.aws.amazon.com/vpc/latest/userguide/flow-log-records.html#flow-logs-fields