### PR TITLE
add Athena table for CloudFront realtime logging

### DIFF
--- a/aws/cloudfront-realtimelog-table/README.md
+++ b/aws/cloudfront-realtimelog-table/README.md
@@ -1,0 +1,58 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for CloudFront realtime log
+
+### Usage
+
+```hcl
+resource "aws_glue_catalog_database" "cf_realtimelog" {
+  name = "cf_realtimelog"
+}
+
+module "cf_realtimelog_table" {
+  source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-realtimelog-table"
+
+  name          = "api"
+  database_name = aws_glue_catalog_database.cf_realtimelog.name
+  location      = "s3://cloudfront-realtimelog/api"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_glue_catalog_table.t](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | The s3 location of the CloudFront realtimelog. (ex: s3://cloudfront-realtimelog/api) | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_partition_range"></a> [partition\_range](#input\_partition\_range) | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1YEARS,NOW"` | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/cloudfront-realtimelog-table/constraints.tf
+++ b/aws/cloudfront-realtimelog-table/constraints.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
+}

--- a/aws/cloudfront-realtimelog-table/main.tf
+++ b/aws/cloudfront-realtimelog-table/main.tf
@@ -30,21 +30,17 @@ resource "aws_glue_catalog_table" "t" {
   parameters = {
     EXTERNAL = "TRUE"
 
-    "skip.header.line.count"    = 2
-    "projection.enabled"        = "true"
-    "projection.year.type"      = "date" # The type must be 'date' to use 'NOW'
-    "projection.year.range"     = var.partition_range
-    "projection.year.format"    = "yyyy"
-    "projection.month.type"     = "integer"
-    "projection.month.range"    = "01,12"
-    "projection.month.digits"   = "2"
-    "projection.day.type"       = "integer"
-    "projection.day.range"      = "01,31"
-    "projection.day.digits"     = "2"
-    "projection.hour.type"      = "integer"
-    "projection.hour.range"     = "00,23"
-    "projection.hour.digits"    = "2"
-    "storage.location.template" = "${var.location}/$${year}/$${month}/$${day}/$${hour}/"
+    "skip.header.line.count"       = 2
+    "projection.enabled"           = "true"
+    "projection.day.type"          = "date"
+    "projection.day.range"         = var.partition_range
+    "projection.day.format"        = "yyyy/MM/dd"
+    "projection.day.interval"      = 1
+    "projection.day.interval.unit" = "DAYS"
+    "projection.hour.type"         = "integer"
+    "projection.hour.range"        = "0,23"
+    "projection.hour.digits"       = "2"
+    "storage.location.template"    = "${var.location}/$${day}/$${hour}/"
   }
 
   storage_descriptor {
@@ -287,22 +283,12 @@ resource "aws_glue_catalog_table" "t" {
   }
 
   partition_keys {
-    name = "year"
-    type = "string"
-  }
-
-  partition_keys {
-    name = "month"
-    type = "string"
-  }
-
-  partition_keys {
     name = "day"
     type = "string"
   }
 
   partition_keys {
     name = "hour"
-    type = "string"
+    type = "int"
   }
 }

--- a/aws/cloudfront-realtimelog-table/main.tf
+++ b/aws/cloudfront-realtimelog-table/main.tf
@@ -1,0 +1,308 @@
+/**
+* ## Information
+*
+* Athena table for CloudFront realtime log
+*
+* ### Usage
+*
+* ```hcl
+* resource "aws_glue_catalog_database" "cf_realtimelog" {
+*   name = "cf_realtimelog"
+* }
+*
+* module "cf_realtimelog_table" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/cloudfront-realtimelog-table"
+*
+*   name          = "api"
+*   database_name = aws_glue_catalog_database.cf_realtimelog.name
+*   location      = "s3://cloudfront-realtimelog/api"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL = "TRUE"
+
+    "skip.header.line.count"    = 2
+    "projection.enabled"        = "true"
+    "projection.year.type"      = "date" # The type must be 'date' to use 'NOW'
+    "projection.year.range"     = var.partition_range
+    "projection.year.format"    = "yyyy"
+    "projection.month.type"     = "integer"
+    "projection.month.range"    = "01,12"
+    "projection.month.digits"   = "2"
+    "projection.day.type"       = "integer"
+    "projection.day.range"      = "01,31"
+    "projection.day.digits"     = "2"
+    "projection.hour.type"      = "integer"
+    "projection.hour.range"     = "00,23"
+    "projection.hour.digits"    = "2"
+    "storage.location.template" = "${var.location}/$${year}/$${month}/$${day}/$${hour}/"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"
+      parameters = {
+        "field.delim" = "\t"
+      }
+    }
+
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/create-cloudfront-table-real-time-logs.html
+    columns {
+      name = "timestamp"
+      type = "string"
+    }
+
+    columns {
+      name = "c_ip"
+      type = "string"
+    }
+
+    columns {
+      name = "time_to_first_byte"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sc_status"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sc_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "cs_method"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_host"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_uri_stem"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_bytes"
+      type = "bigint"
+    }
+
+    columns {
+      name = "x_edge_location"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_request_id"
+      type = "string"
+    }
+
+    columns {
+      name = "x_host_header"
+      type = "string"
+    }
+
+    columns {
+      name = "time_taken"
+      type = "bigint"
+    }
+
+    columns {
+      name = "cs_protocol_version"
+      type = "string"
+    }
+
+    columns {
+      name = "c_ip_version"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_user_agent"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_referer"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_cookie"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_uri_query"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_response_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "x_forwarded_for"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+
+    columns {
+      name = "x_edge_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "fle_encrypted_fields"
+      type = "string"
+    }
+
+    columns {
+      name = "fle_status"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_content_type"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_content_len"
+      type = "bigint"
+    }
+
+    columns {
+      name = "sc_range_start"
+      type = "string"
+    }
+
+    columns {
+      name = "sc_range_end"
+      type = "string"
+    }
+
+    columns {
+      name = "c_port"
+      type = "bigint"
+    }
+
+    columns {
+      name = "x_edge_detailed_result_type"
+      type = "string"
+    }
+
+    columns {
+      name = "c_country"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_accept_encoding"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_accept"
+      type = "string"
+    }
+
+    columns {
+      name = "cache_behavior_path_pattern"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_headers"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_header_names"
+      type = "string"
+    }
+
+    columns {
+      name = "cs_headers_count"
+      type = "bigint"
+    }
+
+    columns {
+      name = "primary_distribution_id"
+      type = "string"
+    }
+
+    columns {
+      name = "primary_distribution_dns_name"
+      type = "string"
+    }
+
+    columns {
+      name = "origin_fbl"
+      type = "string"
+    }
+
+    columns {
+      name = "origin_lbl"
+      type = "string"
+    }
+
+    columns {
+      name = "asn"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "year"
+    type = "string"
+  }
+
+  partition_keys {
+    name = "month"
+    type = "string"
+  }
+
+  partition_keys {
+    name = "day"
+    type = "string"
+  }
+
+  partition_keys {
+    name = "hour"
+    type = "string"
+  }
+}

--- a/aws/cloudfront-realtimelog-table/variables.tf
+++ b/aws/cloudfront-realtimelog-table/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]+$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the CloudFront realtimelog. (ex: s3://cloudfront-realtimelog/api)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1YEARS,NOW"
+}

--- a/aws/cloudfront-realtimelog-table/variables.tf
+++ b/aws/cloudfront-realtimelog-table/variables.tf
@@ -26,5 +26,5 @@ variable "location" {
 variable "partition_range" {
   type        = string
   description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
-  default     = "NOW-1YEARS,NOW"
+  default     = "NOW-1MONTH,NOW"
 }


### PR DESCRIPTION
Added Athena table for CloudFront realtime logging.

The field and type by the realtime-log can be found in the official documentation.
=> https://docs.aws.amazon.com/athena/latest/ug/create-cloudfront-table-real-time-logs.html