### PR TITLE
Bump AWS provider requirement to v6

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -25,13 +25,13 @@ module "ei_privatelink_consumer" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -52,8 +52,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The ID of one or more subnets in which to create a network interface for the endpoint | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the VPC Endpoints are installed | `string` | n/a | yes |
-| <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | CIDR blocks of EI Management Environment | `list(string)` | <pre>[<br>  "10.254.0.0/23"<br>]</pre> | no |
-| <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group IDs of EI Management Environment | `list(string)` | <pre>[<br>  "089928438340/sg-3845ff5c"<br>]</pre> | no |
+| <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | CIDR blocks of EI Management Environment | `list(string)` | <pre>[<br/>  "10.254.0.0/23"<br/>]</pre> | no |
+| <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group IDs of EI Management Environment | `list(string)` | <pre>[<br/>  "089928438340/sg-3845ff5c"<br/>]</pre> | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
 
 ## Outputs

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -35,7 +35,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "this" {
   vpc_id              = var.vpc_id
-  service_name        = local.vpce_service_name[data.aws_region.current.name]
+  service_name        = local.vpce_service_name[data.aws_region.current.region]
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = [aws_security_group.this.id]
@@ -61,6 +61,6 @@ resource "aws_security_group" "ei_managed" {
   name   = "ei-managed"
   vpc_id = var.vpc_id
 
-  ingress = data.aws_region.current.name == "ap-northeast-1" ? local.ei_sg_ids : local.ei_cidrs
+  ingress = data.aws_region.current.region == "ap-northeast-1" ? local.ei_sg_ids : local.ei_cidrs
   egress  = []
 }

--- a/aws/ei-privatelink-consumer/versions.tf
+++ b/aws/ei-privatelink-consumer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2"
+      version = ">= 6.0"
     }
   }
 }

--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -47,13 +47,13 @@ module "redash" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 

--- a/aws/redash/container_definitions.tf
+++ b/aws/redash/container_definitions.tf
@@ -18,7 +18,7 @@ module "server_container_definitions" {
     secretOptions = null
 
     options = merge({
-      awslogs-region        = data.aws_region.current.name
+      awslogs-region        = data.aws_region.current.region
       awslogs-group         = aws_cloudwatch_log_group.logs["server"].name
       awslogs-stream-prefix = "server"
       mode                  = var.ecs_log_mode
@@ -46,7 +46,7 @@ module "worker_container_definition" {
     secretOptions = null
 
     options = merge({
-      awslogs-region        = data.aws_region.current.name
+      awslogs-region        = data.aws_region.current.region
       awslogs-group         = aws_cloudwatch_log_group.logs["worker"].name
       awslogs-stream-prefix = "worker"
       mode                  = var.ecs_log_mode
@@ -75,7 +75,7 @@ module "scheduler_container_definition" {
     secretOptions = null
 
     options = merge({
-      awslogs-region        = data.aws_region.current.name
+      awslogs-region        = data.aws_region.current.region
       awslogs-group         = aws_cloudwatch_log_group.logs["scheduler"].name
       awslogs-stream-prefix = "scheduler"
       mode                  = var.ecs_log_mode
@@ -103,7 +103,7 @@ module "db_create_container_definition" {
     secretOptions = null
 
     options = {
-      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-region"        = data.aws_region.current.region
       "awslogs-group"         = aws_cloudwatch_log_group.logs["db_create"].name
       "awslogs-stream-prefix" = "db-create"
     }
@@ -128,7 +128,7 @@ module "db_migrate_container_definition" {
     secretOptions = null
 
     options = {
-      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-region"        = data.aws_region.current.region
       "awslogs-group"         = aws_cloudwatch_log_group.logs["db_migrate"].name
       "awslogs-stream-prefix" = "db-migrate"
     }
@@ -153,7 +153,7 @@ module "db_upgrade_container_definition" {
     secretOptions = null
 
     options = {
-      "awslogs-region"        = data.aws_region.current.name
+      "awslogs-region"        = data.aws_region.current.region
       "awslogs-group"         = aws_cloudwatch_log_group.logs["db_upgrade"].name
       "awslogs-stream-prefix" = "db-upgrade"
     }

--- a/aws/redash/versions.tf
+++ b/aws/redash/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#data-source-aws_region

The required versions of the two submodules in use have been updated.
