### PR TITLE
Enable propagate_tags for redash ECS service

### DIFF
--- a/aws/redash/README.md
+++ b/aws/redash/README.md
@@ -1,4 +1,3 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Information
 
 Create Redash ECS cluster and its Application load balancer.
@@ -89,33 +88,35 @@ module "redash" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
+| <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | The number of days you want to retain log events | `number` | `90` | no |
 | <a name="input_container_environments"></a> [container\_environments](#input\_container\_environments) | The environments to set to each ECS container | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_container_image_url"></a> [container\_image\_url](#input\_container\_image\_url) | The URL of the image used to launch the container. Images in the Docker Hub registry available by default | `string` | n/a | yes |
 | <a name="input_container_secrets"></a> [container\_secrets](#input\_container\_secrets) | The secrets to set to each ECS container | <pre>list(object({<br/>    name      = string<br/>    valueFrom = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_db_container_cpu"></a> [db\_container\_cpu](#input\_db\_container\_cpu) | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
+| <a name="input_db_container_memory"></a> [db\_container\_memory](#input\_db\_container\_memory) | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
 | <a name="input_ecs_execution_role_arn"></a> [ecs\_execution\_role\_arn](#input\_ecs\_execution\_role\_arn) | The ARN of ECS execution role | `string` | n/a | yes |
+| <a name="input_ecs_log_max_buffer_size"></a> [ecs\_log\_max\_buffer\_size](#input\_ecs\_log\_max\_buffer\_size) | The maximum size of the in-memory buffer used when mode is set to non-blocking | `string` | `"25m"` | no |
+| <a name="input_ecs_log_mode"></a> [ecs\_log\_mode](#input\_ecs\_log\_mode) | The logging mode of ECS | `string` | `"blocking"` | no |
 | <a name="input_ecs_security_group_ids"></a> [ecs\_security\_group\_ids](#input\_ecs\_security\_group\_ids) | The list of security group IDs to assign to the ECS task or service | `list(string)` | n/a | yes |
 | <a name="input_ecs_subnet_ids"></a> [ecs\_subnet\_ids](#input\_ecs\_subnet\_ids) | The list of subnet IDs to assign to the ECS task or service | `list(string)` | n/a | yes |
 | <a name="input_ecs_task_role_arn"></a> [ecs\_task\_role\_arn](#input\_ecs\_task\_role\_arn) | The ARN of the ECS task role | `string` | n/a | yes |
-| <a name="input_lb_certificate_arn"></a> [lb\_certificate\_arn](#input\_lb\_certificate\_arn) | The ARN of the default SSL server certificate | `string` | n/a | yes |
-| <a name="input_lb_security_groups"></a> [lb\_security\_groups](#input\_lb\_security\_groups) | The list of security group IDs to assign to the LB | `list(string)` | n/a | yes |
-| <a name="input_lb_subnets"></a> [lb\_subnets](#input\_lb\_subnets) | The list of subnet IDs to attach to the LB | `list(string)` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
-| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | If true, Public IP is assigned to ECS service | `bool` | `false` | no |
-| <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | The number of days you want to retain log events | `number` | `90` | no |
-| <a name="input_db_container_cpu"></a> [db\_container\_cpu](#input\_db\_container\_cpu) | The number of cpu units to reserve for the container which is used to kick the DB tasks | `number` | `512` | no |
-| <a name="input_db_container_memory"></a> [db\_container\_memory](#input\_db\_container\_memory) | The amount of memory (in MiB) to allow the container to use the DB tasks | `number` | `1024` | no |
-| <a name="input_ecs_log_max_buffer_size"></a> [ecs\_log\_max\_buffer\_size](#input\_ecs\_log\_max\_buffer\_size) | The maximum size of the in-memory buffer used when mode is set to non-blocking | `string` | `"25m"` | no |
-| <a name="input_ecs_log_mode"></a> [ecs\_log\_mode](#input\_ecs\_log\_mode) | The logging mode of ECS | `string` | `"blocking"` | no |
+| <a name="input_enable_ecs_managed_tags"></a> [enable\_ecs\_managed\_tags](#input\_enable\_ecs\_managed\_tags) | Whether to enable Amazon ECS managed tags for the tasks within the service | `bool` | `false` | no |
 | <a name="input_lb_access_log_bucket"></a> [lb\_access\_log\_bucket](#input\_lb\_access\_log\_bucket) | The S3 bucket name to store the logs in | `string` | `null` | no |
 | <a name="input_lb_access_log_prefix"></a> [lb\_access\_log\_prefix](#input\_lb\_access\_log\_prefix) | The prefix (logical hierarchy) in the access log bucket, the logs are placed the `LB_NAME/` if not configured | `string` | `null` | no |
+| <a name="input_lb_certificate_arn"></a> [lb\_certificate\_arn](#input\_lb\_certificate\_arn) | The ARN of the default SSL server certificate | `string` | n/a | yes |
+| <a name="input_lb_security_groups"></a> [lb\_security\_groups](#input\_lb\_security\_groups) | The list of security group IDs to assign to the LB | `list(string)` | n/a | yes |
 | <a name="input_lb_ssl_policy"></a> [lb\_ssl\_policy](#input\_lb\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| <a name="input_lb_subnets"></a> [lb\_subnets](#input\_lb\_subnets) | The list of subnet IDs to attach to the LB | `list(string)` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for the resource names | `string` | `null` | no |
+| <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | Whether to propagate the tags from the task definition or the service to the tasks | `string` | `"NONE"` | no |
 | <a name="input_scheduler_container_cpu"></a> [scheduler\_container\_cpu](#input\_scheduler\_container\_cpu) | The number of cpu units to reserve for the scheduler container | `number` | `1024` | no |
 | <a name="input_scheduler_container_memory"></a> [scheduler\_container\_memory](#input\_scheduler\_container\_memory) | The amount of memory (in MiB) to allow the scheduler container | `number` | `2048` | no |
 | <a name="input_server_container_cpu"></a> [server\_container\_cpu](#input\_server\_container\_cpu) | The number of cpu units to reserve for the server container | `number` | `1024` | no |
 | <a name="input_server_container_memory"></a> [server\_container\_memory](#input\_server\_container\_memory) | The amount of memory (in MiB) to allow the server container | `number` | `2048` | no |
 | <a name="input_server_desired_count"></a> [server\_desired\_count](#input\_server\_desired\_count) | The number of redash server tasks | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of VPC where the load balancer is installed | `string` | n/a | yes |
 | <a name="input_worker_container_cpu"></a> [worker\_container\_cpu](#input\_worker\_container\_cpu) | The number of cpu units to reserve for the worker container | `number` | `1024` | no |
 | <a name="input_worker_container_memory"></a> [worker\_container\_memory](#input\_worker\_container\_memory) | The amount of memory (in MiB) to allow the worker container | `number` | `2048` | no |
 | <a name="input_worker_desired_count"></a> [worker\_desired\_count](#input\_worker\_desired\_count) | The number of redash worker tasks | `number` | `1` | no |
@@ -133,5 +134,3 @@ module "redash" {
 | <a name="output_lb_arn"></a> [lb\_arn](#output\_lb\_arn) | The ARN of LB |
 | <a name="output_lb_dns"></a> [lb\_dns](#output\_lb\_dns) | The DNS name of LB |
 | <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | The Zone ID of LB |
-
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/redash/ecs.tf
+++ b/aws/redash/ecs.tf
@@ -44,6 +44,9 @@ resource "aws_ecs_service" "server" {
     aws_lb_listener.https,
   ]
 
+  enable_ecs_managed_tags = var.enable_ecs_managed_tags
+  propagate_tags          = var.propagate_tags
+
   tags = var.tags
 }
 
@@ -75,6 +78,9 @@ resource "aws_ecs_service" "worker" {
     subnets          = var.ecs_subnet_ids
     assign_public_ip = var.assign_public_ip
   }
+
+  enable_ecs_managed_tags = var.enable_ecs_managed_tags
+  propagate_tags          = var.propagate_tags
 
   tags = var.tags
 }

--- a/aws/redash/variables.tf
+++ b/aws/redash/variables.tf
@@ -172,3 +172,20 @@ variable "tags" {
   default     = {}
   description = "Tags for resources"
 }
+
+variable "enable_ecs_managed_tags" {
+  type        = bool
+  default     = false
+  description = "Whether to enable Amazon ECS managed tags for the tasks within the service"
+}
+
+variable "propagate_tags" {
+  type        = string
+  default     = "NONE"
+  description = "Whether to propagate the tags from the task definition or the service to the tasks"
+
+  validation {
+    condition     = contains(["SERVICE", "TASK_DEFINITION", "NONE"], var.propagate_tags)
+    error_message = "The valid values are SERVICE and TASK_DEFINITION, NONE"
+  }
+}


### PR DESCRIPTION
Continuation of #99.

I'd like to enable the `propagate_tags` for each ECS service.