### PR TITLE
Add a module to periodically restart ECS services

### DIFF
--- a/aws/ecs-service-reloader/README.md
+++ b/aws/ecs-service-reloader/README.md
@@ -1,0 +1,58 @@
+## Information
+
+This module reloads ECS service according to the specified schedule.
+
+### Usage
+
+```hcl
+module "ecs_service_reloader" {
+  source = "github.com/elastic-infra/terraform-modules//aws/ecs-service-reloader?ref=v9.1.0"
+
+  infra_env = var.infra_env
+  targets = [
+    {
+      cluster_name = aws_ecs_cluster.example.name
+      service_name = aws_ecs_service.example.name
+      schedule     = "cron(0 0 * * ? *)"
+      group_name   = "ecs_reload"
+      timezone     = "UTC"
+    },
+  ],
+}
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_scheduler_reload_ecs_role"></a> [scheduler\_reload\_ecs\_role](#module\_scheduler\_reload\_ecs\_role) | github.com/elastic-infra/terraform-modules//aws/iam-service-role | v9.1.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_scheduler_schedule.reload_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/scheduler_schedule) | resource |
+| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_cluster) | data source |
+| [aws_ecs_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecs_service) | data source |
+| [aws_iam_policy_document.scheduler_reload_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_infra_env"></a> [infra\_env](#input\_infra\_env) | infra env | `string` | n/a | yes |
+| <a name="input_targets"></a> [targets](#input\_targets) | Target and schedule settings | <pre>list(object({<br/>    cluster_name = string<br/>    service_name = string<br/>    schedule     = string<br/>    group_name   = optional(string, "default")<br/>    timezone     = optional(string, "Asia/Tokyo")<br/>    state        = optional(string, "ENABLED")<br/>  }))</pre> | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/aws/ecs-service-reloader/event.tf
+++ b/aws/ecs-service-reloader/event.tf
@@ -1,0 +1,35 @@
+locals {
+  targets = { for t in var.targets : "${t.cluster_name}-${t.service_name}" => t }
+}
+
+resource "aws_scheduler_schedule" "reload_ecs" {
+  for_each = local.targets
+
+  # NOTE: name_prefix must be between 1 and 38 characters
+  name_prefix = substr("reload-${each.value.service_name}", 0, 37)
+  description = format("cluster: %s, service: %s", each.value.cluster_name, each.value.service_name)
+  group_name  = each.value.group_name
+  state       = each.value.state
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression          = each.value.schedule
+  schedule_expression_timezone = each.value.timezone
+
+  target {
+    arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
+    role_arn = module.scheduler_reload_ecs_role.role_arn
+
+    input = jsonencode({
+      Cluster            = each.value.cluster_name
+      Service            = each.value.service_name
+      ForceNewDeployment = true
+    })
+
+    retry_policy {
+      maximum_retry_attempts = 1
+    }
+  }
+}

--- a/aws/ecs-service-reloader/iam.tf
+++ b/aws/ecs-service-reloader/iam.tf
@@ -1,0 +1,38 @@
+data "aws_ecs_cluster" "this" {
+  for_each = local.targets
+
+  cluster_name = each.value.cluster_name
+}
+
+data "aws_ecs_service" "this" {
+  for_each = local.targets
+
+  service_name = each.value.service_name
+  cluster_arn  = data.aws_ecs_cluster.this[each.key].arn
+}
+
+data "aws_iam_policy_document" "scheduler_reload_ecs" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "ecs:UpdateService",
+    ]
+
+    resources = values(data.aws_ecs_service.this)[*].arn
+  }
+}
+
+module "scheduler_reload_ecs_role" {
+  source = "github.com/elastic-infra/terraform-modules//aws/iam-service-role?ref=v9.1.0"
+
+  name             = "${var.infra_env}-scheduler-reload-ecs"
+  trusted_services = ["scheduler.amazonaws.com"]
+
+  role_inline_policies = [
+    {
+      name   = "scheduler-reload-ecs"
+      policy = data.aws_iam_policy_document.scheduler_reload_ecs.json
+    },
+  ]
+}

--- a/aws/ecs-service-reloader/main.tf
+++ b/aws/ecs-service-reloader/main.tf
@@ -1,0 +1,25 @@
+/**
+* ## Information
+*
+* This module reloads ECS service according to the specified schedule.
+*
+* ### Usage
+*
+* ```hcl
+* module "ecs_service_reloader" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/ecs-service-reloader?ref=v9.1.0"
+*
+*   infra_env = var.infra_env
+*   targets = [
+*     {
+*       cluster_name = aws_ecs_cluster.example.name
+*       service_name = aws_ecs_service.example.name
+*       schedule     = "cron(0 0 * * ? *)"
+*       group_name   = "ecs_reload"
+*       timezone     = "UTC"
+*     },
+*   ],
+* }
+* ```
+*
+*/

--- a/aws/ecs-service-reloader/variables.tf
+++ b/aws/ecs-service-reloader/variables.tf
@@ -1,0 +1,16 @@
+variable "infra_env" {
+  type        = string
+  description = "infra env"
+}
+
+variable "targets" {
+  type = list(object({
+    cluster_name = string
+    service_name = string
+    schedule     = string
+    group_name   = optional(string, "default")
+    timezone     = optional(string, "Asia/Tokyo")
+    state        = optional(string, "ENABLED")
+  }))
+  description = "Target and schedule settings"
+}


### PR DESCRIPTION
## Summary

ECS receives patches at relatively short intervals, and AWS restarts services as a result. Some ECS services require control over the restart timing, so we want to add a module to manage this.