### PR TITLE
Add dependencies to aws_iam_role_policies_exclusive

### DIFF
--- a/aws/iam-service-role/main.tf
+++ b/aws/iam-service-role/main.tf
@@ -73,7 +73,7 @@ resource "aws_iam_role_policy" "this" {
 
 resource "aws_iam_role_policies_exclusive" "this" {
   role_name    = aws_iam_role.this.name
-  policy_names = var.role_inline_policies[*].name
+  policy_names = keys(aws_iam_role_policy.this)
 }
 
 resource "aws_iam_instance_profile" "this" {


### PR DESCRIPTION
## Summary

Since there are no dependencies, if `aws_iam_role_policy.this` executes before `aws_iam_role_policies_exclusive.this`, an error will occur. Add dependencies to prevent the error.