### PR TITLE
Add placeholder support to avoid circular references in bucket policies

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -168,6 +168,28 @@ manage_bucket_policy = true
 bucket_policy        = data.aws_iam_policy_document.example_bucket_policy.json
 ```
 
+**Avoiding Circular References with `for_each`**
+
+When using `for_each` to generate multiple buckets and their bucket policies, you may encounter circular reference errors.
+
+To avoid this issue, use the `<BUCKET_ARN>` placeholder in the resource field of your bucket policy.
+The module will automatically replace this placeholder with the actual bucket ARN internally.
+
+```hcl
+data "aws_iam_policy_document" "example_bucket_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    actions = ["s3:GetObject"]
+    resources = [
+      "<BUCKET_ARN>/*"  # This will be automatically replaced with the actual bucket ARN
+    ]
+  }
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -204,7 +204,7 @@ data "aws_iam_policy_document" "policy" {
     }
   }
 
-  source_policy_documents = compact([var.bucket_policy])
+  source_policy_documents = compact([try(replace(var.bucket_policy, "\\u003cBUCKET_ARN\\u003e", aws_s3_bucket.b.arn), null)])
 }
 
 resource "aws_s3_bucket_policy" "b" {

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -168,6 +168,28 @@
 * bucket_policy        = data.aws_iam_policy_document.example_bucket_policy.json
 * ```
 *
+* **Avoiding Circular References with `for_each`**
+*
+* When using `for_each` to generate multiple buckets and their bucket policies, you may encounter circular reference errors.
+*
+* To avoid this issue, use the `<BUCKET_ARN>` placeholder in the resource field of your bucket policy.
+* The module will automatically replace this placeholder with the actual bucket ARN internally.
+*
+* ```hcl
+* data "aws_iam_policy_document" "example_bucket_policy" {
+*   statement {
+*     principals {
+*       type        = "Service"
+*       identifiers = ["cloudfront.amazonaws.com"]
+*     }
+*     actions = ["s3:GetObject"]
+*     resources = [
+*       "<BUCKET_ARN>/*"  # This will be automatically replaced with the actual bucket ARN
+*     ]
+*   }
+* }
+* ```
+*
 */
 
 # For "grant"


### PR DESCRIPTION
fix #113 

Introduces `<BUCKET_ARN>` placeholder support that allows users to define bucket policies without circular reference errors when using `for_each`. 
The module automatically replaces placeholders with actual bucket ARNs.