### PR TITLE
feat(base-infra-group): add dms:DescribeReplicationInstances to read policy

### DIFF
--- a/aws/base-infra-group/main.tf
+++ b/aws/base-infra-group/main.tf
@@ -37,8 +37,9 @@ data "aws_iam_policy_document" "infra_system_read" {
 
     actions = [
       "cloudfront:GetDistribution",
-      "es:DescribeDomain",
+      "dms:DescribeReplicationInstances",
       "docdb:DescribeDBInstances",
+      "es:DescribeDomain",
       "memorydb:DescribeClusters",
       "wafv2:GetWebACL",
     ]


### PR DESCRIPTION
## Summary
Add `dms:DescribeReplicationInstances` permission to the `infra_system_read` policy in base-infra-group module.

## Changes
- Add `dms:DescribeReplicationInstances` action to the read policy
- Reorder actions alphabetically

## Testing
- Terraform syntax is valid (no plan execution needed for module-only changes)