### PR TITLE
feat(ei-privatelink-consumer): add cross-region connectivity support

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_ei_cidrs"></a> [ei\_cidrs](#input\_ei\_cidrs) | CIDR blocks of EI Management Environment | `list(string)` | <pre>[<br/>  "10.254.0.0/23"<br/>]</pre> | no |
 | <a name="input_ei_sg_ids"></a> [ei\_sg\_ids](#input\_ei\_sg\_ids) | Security Group IDs of EI Management Environment | `list(string)` | <pre>[<br/>  "089928438340/sg-3845ff5c"<br/>]</pre> | no |
 | <a name="input_private_dns_enabled"></a> [private\_dns\_enabled](#input\_private\_dns\_enabled) | Whether or not to associate a private hosted zone with the specified VPC | `bool` | `true` | no |
+| <a name="input_service_region"></a> [service\_region](#input\_service\_region) | Region where the endpoint service is hosted. If null, uses current region (same-region access). | `string` | `null` | no |
 
 ## Outputs
 

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -27,15 +27,17 @@ locals {
       protocol  = "tcp"
     })
   }
-  ei_sg_ids = length(var.ei_sg_ids) > 0 ? [for v in local.ingress_rules : merge(v, { security_groups = var.ei_sg_ids })] : []
-  ei_cidrs  = length(var.ei_cidrs) > 0 ? [for v in local.ingress_rules : merge(v, { cidr_blocks = var.ei_cidrs })] : []
+  ei_sg_ids     = length(var.ei_sg_ids) > 0 ? [for v in local.ingress_rules : merge(v, { security_groups = var.ei_sg_ids })] : []
+  ei_cidrs      = length(var.ei_cidrs) > 0 ? [for v in local.ingress_rules : merge(v, { cidr_blocks = var.ei_cidrs })] : []
+  target_region = coalesce(var.service_region, data.aws_region.current.region)
 }
 
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "this" {
   vpc_id              = var.vpc_id
-  service_name        = local.vpce_service_name[data.aws_region.current.region]
+  service_name        = local.vpce_service_name[local.target_region]
+  service_region      = var.service_region
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = [aws_security_group.this.id]

--- a/aws/ei-privatelink-consumer/variables.tf
+++ b/aws/ei-privatelink-consumer/variables.tf
@@ -3,6 +3,12 @@ variable "vpc_id" {
   description = "VPC ID where the VPC Endpoints are installed"
 }
 
+variable "service_region" {
+  type        = string
+  description = "Region where the endpoint service is hosted. If null, uses current region (same-region access)."
+  default     = null
+}
+
 variable "subnet_ids" {
   type        = list(string)
   description = "The ID of one or more subnets in which to create a network interface for the endpoint"


### PR DESCRIPTION
## Summary

- Add `service_region` variable to enable cross-region PrivateLink access
- When specified, consumers can connect to the EI endpoint service hosted in a different region without VPC/TGW peering
- Fully backward compatible: existing users require no changes (`service_region` defaults to `null`)

## Usage

```hcl
# Same-region (existing behavior, no changes needed)
module "ei_privatelink_consumer" {
  source     = "../module/aws/common/ei-privatelink-consumer"
  vpc_id     = module.vpc.vpc_id
  subnet_ids = module.vpc.public_subnets
}

# Cross-region
module "ei_privatelink_consumer" {
  source         = "../module/aws/common/ei-privatelink-consumer"
  vpc_id         = module.vpc.vpc_id
  subnet_ids     = module.vpc.public_subnets
  service_region = "ap-northeast-1"
}
```