### PR TITLE
Specify runtime platform

### DIFF
--- a/aws/fargate-bastion/README.md
+++ b/aws/fargate-bastion/README.md
@@ -63,6 +63,7 @@ resource "local_file" "proxy_command" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_ecs"></a> [ecs](#input\_ecs) | Parameters of ECS bastion | <pre>object({<br/>    cluster            = optional(string)<br/>    subnets            = list(string)<br/>    security_groups    = list(string)<br/>    container_insights = optional(bool, false)<br/>    log_configuration = optional(object({<br/>      logDriver = string<br/>      options   = map(string)<br/>      secretOptions = optional(list(object({<br/>        name      = string<br/>        valueFrom = string<br/>      })))<br/>    }))<br/>    log_configuration_timer = optional(object({<br/>      logDriver = string<br/>      options   = map(string)<br/>      secretOptions = optional(list(object({<br/>        name      = string<br/>        valueFrom = string<br/>      })))<br/>    }))<br/>  })</pre> | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix for all resources | `string` | n/a | yes |
+| <a name="input_cpu_architecture"></a> [cpu\_architecture](#input\_cpu\_architecture) | CPU architecture for ECS task (X86\_64 or ARM64) | `string` | `"X86_64"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for resources | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | ECS task timeout | `number` | `3600` | no |
 

--- a/aws/fargate-bastion/ecs.tf
+++ b/aws/fargate-bastion/ecs.tf
@@ -61,6 +61,11 @@ resource "aws_ecs_task_definition" "bastion" {
   cpu                      = 512
   memory                   = 1024
 
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+
   tags = var.tags
 }
 

--- a/aws/fargate-bastion/variables.tf
+++ b/aws/fargate-bastion/variables.tf
@@ -35,6 +35,17 @@ variable "timeout" {
   default     = 60 * 60
 }
 
+variable "cpu_architecture" {
+  type        = string
+  description = "CPU architecture for ECS task (X86_64 or ARM64)"
+  default     = "X86_64"
+
+  validation {
+    condition     = contains(["X86_64", "ARM64"], var.cpu_architecture)
+    error_message = "cpu_architecture must be X86_64 or ARM64."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags for resources"


### PR DESCRIPTION
Explicitly specify cpu_architecture to avoid detection by ECS.21 in SecurityHub CSPM.