### PR TITLE
feat(ei-privatelink-consumer): use aws_vpc_endpoint_private_dns for in-place private DNS management

### DIFF
--- a/aws/ei-privatelink-consumer/README.md
+++ b/aws/ei-privatelink-consumer/README.md
@@ -44,6 +44,7 @@ No modules.
 | [aws_security_group.ei_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_vpc_endpoint_private_dns.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_private_dns) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/aws/ei-privatelink-consumer/main.tf
+++ b/aws/ei-privatelink-consumer/main.tf
@@ -35,16 +35,20 @@ locals {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "this" {
-  vpc_id              = var.vpc_id
-  service_name        = local.vpce_service_name[local.target_region]
-  service_region      = var.service_region
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = var.subnet_ids
-  security_group_ids  = [aws_security_group.this.id]
-  private_dns_enabled = var.private_dns_enabled
+  vpc_id             = var.vpc_id
+  service_name       = local.vpce_service_name[local.target_region]
+  service_region     = var.service_region
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = var.subnet_ids
+  security_group_ids = [aws_security_group.this.id]
   tags = {
     Name = "Elastic Infra Common Service"
   }
+}
+
+resource "aws_vpc_endpoint_private_dns" "this" {
+  vpc_endpoint_id     = aws_vpc_endpoint.this.id
+  private_dns_enabled = var.private_dns_enabled
 }
 
 resource "aws_security_group" "this" {


### PR DESCRIPTION
## Summary

- Remove `private_dns_enabled` from `aws_vpc_endpoint` resource and manage it via `aws_vpc_endpoint_private_dns` resource instead

## Background

In terraform-provider-aws v6.28.0, `private_dns_enabled` on `aws_vpc_endpoint` was changed to ForceNew, causing VPC Endpoint recreation when the value changes.

The `aws_vpc_endpoint_private_dns` resource (available since v5.51.0) uses the `ModifyVpcEndpoint` API to toggle private DNS in-place, avoiding endpoint recreation.

## Impact on existing deployments

No `terraform state` commands or `moved` blocks are required.

- `aws_vpc_endpoint.this`: `private_dns_enabled` is a Computed attribute, so removing it from config produces no diff
- `aws_vpc_endpoint_private_dns.this`: Will be created. Calls `ModifyVpcEndpoint` API to set `private_dns_enabled = true`, which is a no-op if already enabled