### PR TITLE
feat(mysql/users): add write-only password support

### DIFF
--- a/mysql/users/README.md
+++ b/mysql/users/README.md
@@ -27,7 +27,8 @@ module "main_users" {
       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
     }
     user2 = {
-      password = data.aws_kms_secrets.db_user.plaintext["user2"]
+      password_wo         = data.aws_kms_secrets.db_user.plaintext["user2"]
+      password_wo_version = 1
       privileges = {
         "${mysql_database.db.name}.table1" = ["SELECT"]
       }
@@ -40,7 +41,9 @@ module "main_users" {
 }
 ```
 
-* `password` - The password for the user.
+* `password` - The password for the user. The unsalted hash of the password is stored in the state.
+* `password_wo` - The password for the user. Unlike `password`, this is not stored in the state. Requires Terraform v1.11+.
+* `password_wo_version` - A version number to trigger password updates when using `password_wo`. Increment this to rotate the password.
 * `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
 * `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
 
@@ -48,14 +51,14 @@ module "main_users" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_mysql"></a> [mysql](#requirement\_mysql) | >= 3.0.87 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3 |
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3.0.87 |
 
 ## Modules
 
@@ -74,7 +77,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br/>    host          = optional(string, "%")<br/>    password      = string<br/>    tls_option    = optional(string)<br/>    auth_plugin   = optional(string)<br/>    privileges    = map(list(string))<br/>    roles         = optional(list(string), [])<br/>    default_roles = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br/>    host                = optional(string, "%")<br/>    password            = optional(string)<br/>    password_wo         = optional(string)<br/>    password_wo_version = optional(number)<br/>    tls_option          = optional(string)<br/>    auth_plugin         = optional(string)<br/>    privileges          = map(list(string))<br/>    roles               = optional(list(string), [])<br/>    default_roles       = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -27,7 +27,8 @@
 *       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
 *     }
 *     user2 = {
-*       password = data.aws_kms_secrets.db_user.plaintext["user2"]
+*       password_wo         = data.aws_kms_secrets.db_user.plaintext["user2"]
+*       password_wo_version = 1
 *       privileges = {
 *         "${mysql_database.db.name}.table1" = ["SELECT"]
 *       }
@@ -40,7 +41,9 @@
 * }
 * ```
 *
-* * `password` - The password for the user.
+* * `password` - The password for the user. The unsalted hash of the password is stored in the state.
+* * `password_wo` - The password for the user. Unlike `password`, this is not stored in the state. Requires Terraform v1.11+.
+* * `password_wo_version` - A version number to trigger password updates when using `password_wo`. Increment this to rotate the password.
 * * `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
 * * `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
 */
@@ -48,11 +51,13 @@
 resource "mysql_user" "users" {
   for_each = var.users
 
-  user               = each.key
-  host               = each.value["host"]
-  plaintext_password = each.value["password"]
-  auth_plugin        = each.value["auth_plugin"]
-  tls_option         = each.value["tls_option"]
+  user                = each.key
+  host                = each.value["host"]
+  plaintext_password  = each.value["password"]
+  password_wo         = each.value["password_wo"]
+  password_wo_version = each.value["password_wo_version"]
+  auth_plugin         = each.value["auth_plugin"]
+  tls_option          = each.value["tls_option"]
 }
 
 locals {

--- a/mysql/users/variables.tf
+++ b/mysql/users/variables.tf
@@ -1,13 +1,23 @@
 variable "users" {
   description = "Specify mysql users and grants. The key is the user name, and value is the password and grants."
   type = map(object({
-    host          = optional(string, "%")
-    password      = string
-    tls_option    = optional(string)
-    auth_plugin   = optional(string)
-    privileges    = map(list(string))
-    roles         = optional(list(string), [])
-    default_roles = optional(list(string), [])
+    host                = optional(string, "%")
+    password            = optional(string)
+    password_wo         = optional(string)
+    password_wo_version = optional(number)
+    tls_option          = optional(string)
+    auth_plugin         = optional(string)
+    privileges          = map(list(string))
+    roles               = optional(list(string), [])
+    default_roles       = optional(list(string), [])
   }))
   default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.users :
+      !(v.password != null && v.password_wo != null)
+    ])
+    error_message = "Each user must not have both 'password' and 'password_wo' set. Use one or the other."
+  }
 }

--- a/mysql/users/versions.tf
+++ b/mysql/users/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.11"
   required_providers {
     mysql = {
       source  = "petoju/mysql"
-      version = ">= 3"
+      version = ">= 3.0.87"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `password_wo` and `password_wo_version` optional attributes to `mysql/users` module
- Supports write-only passwords introduced in petoju/mysql provider v3.0.87, which are not persisted in Terraform state
- Change `password` from required to optional (needed for `auth_plugin` users with no password)
- Add validation ensuring `password` and `password_wo` are mutually exclusive
- Bump required Terraform version to `>= 1.11` and provider version to `>= 3.0.87`

## Test plan

- [x] `terraform validate` passes
- [ ] Verify existing `password` usage is unaffected (no plan diff)
- [ ] Verify `auth_plugin` users with `password = null` still work
- [ ] Test `password_wo` + `password_wo_version` creates user correctly