### PR TITLE
fix(mysql/users): separate password_wo as ephemeral variable

### DIFF
--- a/mysql/users/README.md
+++ b/mysql/users/README.md
@@ -3,19 +3,13 @@
 
 Create mysql users with grants
 
-### Usage
+### Usage with `password`
+
+Password hash is stored in the state.
 
 ```hcl
-resource "mysql_database" "db" {
-  provider = mysql.main
-
-  name                  = "example"
-  default_character_set = "utf8mb4"
-  default_collation     = "utf8mb4_general_ci"
-}
-
 module "main_users" {
-  source = "github.com/elastic-infra/terraform-modules//mysql/users?ref=v6.2.0"
+  source = "github.com/elastic-infra/terraform-modules//mysql/users"
 
   users = {
     user1 = {
@@ -26,13 +20,42 @@ module "main_users" {
       }
       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
     }
-    user2 = {
-      password_wo         = data.aws_kms_secrets.db_user.plaintext["user2"]
+  }
+
+  providers = {
+    mysql = mysql.main
+  }
+}
+```
+
+### Usage with `password_wo`
+
+Password is not stored in the state. Requires Terraform v1.11+.
+The `password_wo` variable is a separate ephemeral variable that accepts values from ephemeral resources.
+
+```hcl
+ephemeral "aws_kms_secrets" "db_user" {
+  secret {
+    name    = "user1"
+    payload = "AQICAHg..."
+  }
+}
+
+module "main_users" {
+  source = "github.com/elastic-infra/terraform-modules//mysql/users"
+
+  users = {
+    user1 = {
       password_wo_version = 1
       privileges = {
-        "${mysql_database.db.name}.table1" = ["SELECT"]
+        mysql_database.db.name = ["ALL PRIVILEGES"]
+        "*"                    = ["SESSION_VARIABLES_ADMIN"]
       }
     }
+  }
+
+  password_wo = {
+    user1 = ephemeral.aws_kms_secrets.db_user.plaintext["user1"]
   }
 
   providers = {
@@ -42,7 +65,7 @@ module "main_users" {
 ```
 
 * `password` - The password for the user. The unsalted hash of the password is stored in the state.
-* `password_wo` - The password for the user. Unlike `password`, this is not stored in the state. Requires Terraform v1.11+.
+* `password_wo` - A separate ephemeral variable. Map of user names to write-only passwords. Not stored in the state.
 * `password_wo_version` - A version number to trigger password updates when using `password_wo`. Increment this to rotate the password.
 * `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
 * `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
@@ -58,7 +81,7 @@ module "main_users" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | >= 3.0.87 |
+| <a name="provider_mysql"></a> [mysql](#provider\_mysql) | 3.0.93 |
 
 ## Modules
 
@@ -77,7 +100,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br/>    host                = optional(string, "%")<br/>    password            = optional(string)<br/>    password_wo         = optional(string)<br/>    password_wo_version = optional(number)<br/>    tls_option          = optional(string)<br/>    auth_plugin         = optional(string)<br/>    privileges          = map(list(string))<br/>    roles               = optional(list(string), [])<br/>    default_roles       = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_password_wo"></a> [password\_wo](#input\_password\_wo) | Map of user names to write-only passwords. These are ephemeral and not stored in state. | `map(string)` | `{}` | no |
+| <a name="input_users"></a> [users](#input\_users) | Specify mysql users and grants. The key is the user name, and value is the password and grants. | <pre>map(object({<br/>    host                = optional(string, "%")<br/>    password            = optional(string)<br/>    password_wo_version = optional(number)<br/>    tls_option          = optional(string)<br/>    auth_plugin         = optional(string)<br/>    privileges          = map(list(string))<br/>    roles               = optional(list(string), [])<br/>    default_roles       = optional(list(string), [])<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/mysql/users/main.tf
+++ b/mysql/users/main.tf
@@ -3,19 +3,13 @@
 *
 * Create mysql users with grants
 *
-* ### Usage
+* ### Usage with `password`
+*
+* Password hash is stored in the state.
 *
 * ```hcl
-* resource "mysql_database" "db" {
-*   provider = mysql.main
-*
-*   name                  = "example"
-*   default_character_set = "utf8mb4"
-*   default_collation     = "utf8mb4_general_ci"
-* }
-*
 * module "main_users" {
-*   source = "github.com/elastic-infra/terraform-modules//mysql/users?ref=v6.2.0"
+*   source = "github.com/elastic-infra/terraform-modules//mysql/users"
 *
 *   users = {
 *     user1 = {
@@ -26,13 +20,42 @@
 *       }
 *       roles = ["AWS_LOAD_S3_ACCESS", "AWS_SELECT_S3_ACCESS"]
 *     }
-*     user2 = {
-*       password_wo         = data.aws_kms_secrets.db_user.plaintext["user2"]
+*   }
+*
+*   providers = {
+*     mysql = mysql.main
+*   }
+* }
+* ```
+*
+* ### Usage with `password_wo`
+*
+* Password is not stored in the state. Requires Terraform v1.11+.
+* The `password_wo` variable is a separate ephemeral variable that accepts values from ephemeral resources.
+*
+* ```hcl
+* ephemeral "aws_kms_secrets" "db_user" {
+*   secret {
+*     name    = "user1"
+*     payload = "AQICAHg..."
+*   }
+* }
+*
+* module "main_users" {
+*   source = "github.com/elastic-infra/terraform-modules//mysql/users"
+*
+*   users = {
+*     user1 = {
 *       password_wo_version = 1
 *       privileges = {
-*         "${mysql_database.db.name}.table1" = ["SELECT"]
+*         mysql_database.db.name = ["ALL PRIVILEGES"]
+*         "*"                    = ["SESSION_VARIABLES_ADMIN"]
 *       }
 *     }
+*   }
+*
+*   password_wo = {
+*     user1 = ephemeral.aws_kms_secrets.db_user.plaintext["user1"]
 *   }
 *
 *   providers = {
@@ -42,7 +65,7 @@
 * ```
 *
 * * `password` - The password for the user. The unsalted hash of the password is stored in the state.
-* * `password_wo` - The password for the user. Unlike `password`, this is not stored in the state. Requires Terraform v1.11+.
+* * `password_wo` - A separate ephemeral variable. Map of user names to write-only passwords. Not stored in the state.
 * * `password_wo_version` - A version number to trigger password updates when using `password_wo`. Increment this to rotate the password.
 * * `privileges` - The keys are targets to grant privileges on. You specify asterisk`*`, database name or `database.table`(join database name and table name with dot). The value is the list of privileges to grant to the user.
 * * `roles` - Only supported in MySQL 8 and above. A list of roles to grant to the user.
@@ -54,7 +77,7 @@ resource "mysql_user" "users" {
   user                = each.key
   host                = each.value["host"]
   plaintext_password  = each.value["password"]
-  password_wo         = each.value["password_wo"]
+  password_wo         = lookup(var.password_wo, each.key, null)
   password_wo_version = each.value["password_wo_version"]
   auth_plugin         = each.value["auth_plugin"]
   tls_option          = each.value["tls_option"]

--- a/mysql/users/variables.tf
+++ b/mysql/users/variables.tf
@@ -3,7 +3,6 @@ variable "users" {
   type = map(object({
     host                = optional(string, "%")
     password            = optional(string)
-    password_wo         = optional(string)
     password_wo_version = optional(number)
     tls_option          = optional(string)
     auth_plugin         = optional(string)
@@ -16,8 +15,15 @@ variable "users" {
   validation {
     condition = alltrue([
       for k, v in var.users :
-      !(v.password != null && v.password_wo != null)
+      !(v.password != null && contains(keys(var.password_wo), k))
     ])
-    error_message = "Each user must not have both 'password' and 'password_wo' set. Use one or the other."
+    error_message = "Each user must not have both 'password' and an entry in 'password_wo'. Use one or the other."
   }
+}
+
+variable "password_wo" {
+  description = "Map of user names to write-only passwords. These are ephemeral and not stored in state."
+  type        = map(string)
+  default     = {}
+  ephemeral   = true
 }


### PR DESCRIPTION
## Summary

- Move `password_wo` out of the `users` object into a standalone `ephemeral = true` variable
- Enables passing values from ephemeral resources (e.g. `ephemeral "aws_kms_secrets"`) to the module
- `password_wo_version` remains in the `users` object as it is non-sensitive

## Background

In v9.5.0, `password_wo` was inside the `users` object. Passing ephemeral resource values caused:

```
Error: Ephemeral value not allowed
This input variable is not declared as accepting ephemeral values
```

Marking the entire `users` variable as `ephemeral = true` would make non-sensitive fields (`host`, `privileges`, etc.) ephemeral too, breaking `mysql_grant` and other normal resources.

## Test plan

- [x] `terraform validate` passes
- [ ] Verify ephemeral resource values can be passed via `password_wo`
- [ ] Verify existing `password` usage is unaffected