### PR TITLE
feat(private-s3-bucket): add region variable and require aws provider v6

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -195,13 +195,13 @@ data "aws_iam_policy_document" "example_bucket_policy" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -242,6 +242,7 @@ No modules.
 | <a name="input_mfa_delete"></a> [mfa\_delete](#input\_mfa\_delete) | Enable MFA delete, this requires the versioning feature | `bool` | `false` | no |
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br/>    rule = object({<br/>      default_retention = object({<br/>        mode  = string<br/>        days  = number<br/>        years = number<br/>      })<br/>    })<br/>  }))</pre> | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region where the bucket and its configurations are created. When null, uses the provider's configured region. | `string` | `null` | no |
 | <a name="input_sse_kms_master_key_id"></a> [sse\_kms\_master\_key\_id](#input\_sse\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | S3 object versioning settings | `bool` | `null` | no |

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -1,5 +1,8 @@
 resource "aws_s3_bucket_versioning" "b" {
-  count  = var.versioning != null ? 1 : 0
+  count = var.versioning != null ? 1 : 0
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
   versioning_configuration {
     status     = var.versioning ? "Enabled" : "Suspended"
@@ -8,7 +11,10 @@ resource "aws_s3_bucket_versioning" "b" {
 }
 
 resource "aws_s3_bucket_logging" "b" {
-  count  = length(var.logging) > 0 ? 1 : 0
+  count = length(var.logging) > 0 ? 1 : 0
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   target_bucket = var.logging[0].target_bucket
@@ -17,7 +23,10 @@ resource "aws_s3_bucket_logging" "b" {
 
 # grant
 resource "aws_s3_bucket_acl" "b" {
-  count  = local.object_ownership != "BucketOwnerEnforced" ? 1 : 0
+  count = local.object_ownership != "BucketOwnerEnforced" ? 1 : 0
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   acl = length(var.grant) > 0 ? null : "private"
@@ -55,6 +64,8 @@ resource "aws_s3_bucket_acl" "b" {
 
 # Bucket Ownership Controls
 resource "aws_s3_bucket_ownership_controls" "b" {
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   rule {
@@ -64,6 +75,8 @@ resource "aws_s3_bucket_ownership_controls" "b" {
 
 # lifecycle
 resource "aws_s3_bucket_lifecycle_configuration" "b" {
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   rule {
@@ -137,7 +150,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "b" {
 }
 # SSE
 resource "aws_s3_bucket_server_side_encryption_configuration" "b" {
-  count  = var.disable_sse ? 0 : 1
+  count = var.disable_sse ? 0 : 1
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   rule {
@@ -149,7 +165,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "b" {
 }
 # CORS
 resource "aws_s3_bucket_cors_configuration" "b" {
-  count  = length(var.cors_rule) > 0 ? 1 : 0
+  count = length(var.cors_rule) > 0 ? 1 : 0
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   dynamic "cors_rule" {
@@ -165,7 +184,10 @@ resource "aws_s3_bucket_cors_configuration" "b" {
 }
 # Object Lock
 resource "aws_s3_bucket_object_lock_configuration" "b" {
-  count  = length(var.object_lock_configuration) > 0 ? 1 : 0
+  count = length(var.object_lock_configuration) > 0 ? 1 : 0
+
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   rule {
@@ -209,6 +231,8 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_s3_bucket_policy" "b" {
   count = length(data.aws_iam_policy_document.policy)
+
+  region = var.region
 
   bucket = aws_s3_bucket.b.id
   policy = data.aws_iam_policy_document.policy[0].json

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/aws/private-s3-bucket/example/provider.tf
+++ b/aws/private-s3-bucket/example/provider.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -201,6 +201,8 @@ locals {
 }
 
 resource "aws_s3_bucket" "b" {
+  region = var.region
+
   bucket = var.bucket_name
   tags   = var.tags
 
@@ -208,6 +210,8 @@ resource "aws_s3_bucket" "b" {
 }
 
 resource "aws_s3_bucket_public_access_block" "b" {
+  region = var.region
+
   bucket = aws_s3_bucket.b.id
 
   # ACL should always not be used nor used

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -1,3 +1,9 @@
+variable "region" {
+  type        = string
+  default     = null
+  description = "AWS region where the bucket and its configurations are created. When null, uses the provider's configured region."
+}
+
 variable "bucket_name" {
   type        = string
   description = "S3 bucket name"


### PR DESCRIPTION
## Summary

- Add `region` variable (default `null`) to `private-s3-bucket` module and propagate `region = var.region` to all `aws_*` resources.
- Bump AWS provider constraint from `>= 4.0.0` to `>= 6.0` to enable the [Enhanced Region Support](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support) feature.
- Update the `example/provider.tf` constraint to match.

## Motivation

Callers that want to create a bucket in a non-default region currently need to define a provider alias and pass it in via `providers = { aws = aws.foo }`. With the v6 `region` attribute, callers can now simply pass `region = "us-east-1"` to this module.

## Breaking change

- Provider constraint is raised to `>= 6.0`; consumers still on AWS provider v5 or below must upgrade the provider before using the new module version.
- Existing callers that do **not** set `var.region` see no behavioral change: `region = null` falls back to the default provider region.

## Notes

- `data "aws_canonical_user_id"` does not accept the `region` attribute (local API that does not support it), so it is left as-is.
- `data "aws_iam_policy_document"` is provider-local (synthesizes JSON) and has no region attribute.
- README regenerated via `make -f aws/tools/Makefile`.

## Test plan

- [x] `terraform fmt` / `terraform-docs` via `make` — README updated
- [x] `terraform init` + `terraform validate` in `example/` — success
- [ ] Manual `terraform plan` in a real consumer state with `var.region` unset — expect no diff
- [ ] Manual `terraform plan` with `region = "us-east-2"` — expect resources targeted at us-east-2