### PR TITLE
feat(vpc-peering-multiaccount): add region variable and require aws provider v6

### DIFF
--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -12,7 +12,7 @@ Users of this module need to set up the requester side in other means in advance
 
 ```hcl
 module "peering_acceptance" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=10.0.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v10.0.0"
 
   region = "us-east-1"
 

--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -12,7 +12,7 @@ Users of this module need to set up the requester side in other means in advance
 
 ```hcl
 module "peering_acceptance" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v2.3.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v3.0.0"
 
   enabled                   = "true"
   namespace                 = "foo"
@@ -22,13 +22,10 @@ module "peering_acceptance" {
   requester_vpc_cidr_blocks = ["198.51.100/24"]
   accepter_vpc_id           = "vpc-0123456789"
   vpc_peering_id            = "pcx-0123456789abcdef"
+  region                    = "us-east-1"
 
   tags {
     Environment = "development"
-  }
-
-  providers = {
-    aws = aws.us-east-1
   }
 }
 ```
@@ -37,14 +34,14 @@ module "peering_acceptance" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -77,6 +74,7 @@ module "peering_acceptance" {
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `a` or `b`) | `list(string)` | `[]` | no |
 | <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes` | `string` | `"-"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating or accessing any resources | `string` | `"true"` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region where the accepter-side resources are created. When null, uses the provider's configured region. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{"BusinessUnit" = "XYZ"`) | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/aws/vpc-peering-accepter-multiaccount/README.md
+++ b/aws/vpc-peering-accepter-multiaccount/README.md
@@ -12,7 +12,9 @@ Users of this module need to set up the requester side in other means in advance
 
 ```hcl
 module "peering_acceptance" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v3.0.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=10.0.0"
+
+  region = "us-east-1"
 
   enabled                   = "true"
   namespace                 = "foo"
@@ -22,7 +24,6 @@ module "peering_acceptance" {
   requester_vpc_cidr_blocks = ["198.51.100/24"]
   accepter_vpc_id           = "vpc-0123456789"
   vpc_peering_id            = "pcx-0123456789abcdef"
-  region                    = "us-east-1"
 
   tags {
     Environment = "development"

--- a/aws/vpc-peering-accepter-multiaccount/accepter.tf
+++ b/aws/vpc-peering-accepter-multiaccount/accepter.tf
@@ -19,13 +19,19 @@ module "accepter_label" {
 # Lookup accepter VPC so that we can reference the CIDR
 data "aws_vpc" "accepter" {
   count = local.count
-  id    = var.accepter_vpc_id
-  tags  = var.accepter_vpc_tags
+
+  region = var.region
+
+  id   = var.accepter_vpc_id
+  tags = var.accepter_vpc_tags
 }
 
 # Lookup accepter subnets
 data "aws_subnets" "accepter" {
   count = local.count
+
+  region = var.region
+
   filter {
     name   = "vpc-id"
     values = [local.accepter_vpc_id]
@@ -41,12 +47,16 @@ locals {
 # Lookup peering connection
 data "aws_vpc_peering_connection" "peering" {
   count = local.count
-  id    = var.vpc_peering_id
+
+  id = var.vpc_peering_id
 }
 
 # Lookup accepter route tables
 data "aws_route_table" "accepter" {
-  count     = local.enabled ? local.accepter_subnet_ids_count : 0
+  count = local.enabled ? local.accepter_subnet_ids_count : 0
+
+  region = var.region
+
   subnet_id = element(local.accepter_subnet_ids, count.index)
 }
 
@@ -55,6 +65,8 @@ locals {
 }
 
 resource "aws_vpc_peering_connection_accepter" "accepter" {
+  region = var.region
+
   vpc_peering_connection_id = local.vpc_peering_connection_id
   auto_accept               = true
   tags                      = module.accepter_label.tags
@@ -70,7 +82,10 @@ locals {
 }
 
 resource "aws_route" "to_requester" {
-  count                     = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
+  count = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
+
+  region = var.region
+
   route_table_id            = element(local.accepter_aws_route_table_ids, ceil(count.index / local.requester_cidr_block_associations_count))
   destination_cidr_block    = element(local.requester_cidr_block_associations, count.index % local.requester_cidr_block_associations_count)
   vpc_peering_connection_id = local.vpc_peering_connection_id

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -12,7 +12,7 @@
 *
 * ```hcl
 * module "peering_acceptance" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=10.0.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v10.0.0"
 *
 *   region = "us-east-1"
 *

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -12,7 +12,9 @@
 *
 * ```hcl
 * module "peering_acceptance" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v3.0.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=10.0.0"
+*
+*   region = "us-east-1"
 *
 *   enabled                   = "true"
 *   namespace                 = "foo"
@@ -22,7 +24,6 @@
 *   requester_vpc_cidr_blocks = ["198.51.100/24"]
 *   accepter_vpc_id           = "vpc-0123456789"
 *   vpc_peering_id            = "pcx-0123456789abcdef"
-*   region                    = "us-east-1"
 *
 *   tags {
 *     Environment = "development"

--- a/aws/vpc-peering-accepter-multiaccount/main.tf
+++ b/aws/vpc-peering-accepter-multiaccount/main.tf
@@ -12,7 +12,7 @@
 *
 * ```hcl
 * module "peering_acceptance" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v2.3.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-accepter-multiaccount?ref=v3.0.0"
 *
 *   enabled                   = "true"
 *   namespace                 = "foo"
@@ -22,13 +22,10 @@
 *   requester_vpc_cidr_blocks = ["198.51.100/24"]
 *   accepter_vpc_id           = "vpc-0123456789"
 *   vpc_peering_id            = "pcx-0123456789abcdef"
+*   region                    = "us-east-1"
 *
 *   tags {
 *     Environment = "development"
-*   }
-*
-*   providers = {
-*     aws = aws.us-east-1
 *   }
 * }
 * ```
@@ -37,14 +34,4 @@
 locals {
   enabled = var.enabled == "true"
   count   = local.enabled ? 1 : 0
-}
-
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2"
-    }
-  }
 }

--- a/aws/vpc-peering-accepter-multiaccount/variables.tf
+++ b/aws/vpc-peering-accepter-multiaccount/variables.tf
@@ -1,3 +1,9 @@
+variable "region" {
+  type        = string
+  default     = null
+  description = "AWS region where the accepter-side resources are created. When null, uses the provider's configured region."
+}
+
 variable "enabled" {
   default     = "true"
   type        = string

--- a/aws/vpc-peering-accepter-multiaccount/versions.tf
+++ b/aws/vpc-peering-accepter-multiaccount/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -16,7 +16,7 @@ peer VPC resides in and is passed to `aws_vpc_peering_connection.peer_region`.
 
 ```hcl
 module "peering-request" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=10.0.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v10.0.0"
 
   region = "us-east-1"
 

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -16,7 +16,9 @@ peer VPC resides in and is passed to `aws_vpc_peering_connection.peer_region`.
 
 ```hcl
 module "peering-request" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v3.0.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=10.0.0"
+
+  region = "us-east-1"
 
   enabled              = "true"
   namespace            = "foo"
@@ -26,7 +28,6 @@ module "peering-request" {
   requester_vpc_id     = "vpc-12345678"
   peer_owner_id        = "012345678901"
   peer_vpc_id          = "vpc-0123456789abcdef"
-  region               = "us-east-1"
   peer_region          = "us-west-1"
   peer_vpc_cidr_blocks = ["192.0.2.0/24"]
   tags {

--- a/aws/vpc-peering-requester-multiaccount/README.md
+++ b/aws/vpc-peering-requester-multiaccount/README.md
@@ -9,11 +9,14 @@ set up the route to the peer (blackhole then) on the requester side.
 Users of this module need to set up the accepter side in other means, by accepting the VPC peering connection and
 set up the route to the requester.
 
+`region` specifies where the requester-side resources are created; `peer_region` is the region the
+peer VPC resides in and is passed to `aws_vpc_peering_connection.peer_region`.
+
 ## Usage Example
 
 ```hcl
 module "peering-request" {
-  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v2.3.0"
+  source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v3.0.0"
 
   enabled              = "true"
   namespace            = "foo"
@@ -23,14 +26,11 @@ module "peering-request" {
   requester_vpc_id     = "vpc-12345678"
   peer_owner_id        = "012345678901"
   peer_vpc_id          = "vpc-0123456789abcdef"
+  region               = "us-east-1"
   peer_region          = "us-west-1"
   peer_vpc_cidr_blocks = ["192.0.2.0/24"]
   tags {
     Environment = "development"
-  }
-
-  providers = {
-    aws = aws.us-east-1
   }
 }
 ```
@@ -39,14 +39,14 @@ module "peering-request" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -79,6 +79,7 @@ module "peering-request" {
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating or accessing any resources | `string` | `"true"` | no |
 | <a name="input_peer_region"></a> [peer\_region](#input\_peer\_region) | Region where peer VPC resides; Cannot be set when peering\_auto\_accept is true | `string` | `null` | no |
 | <a name="input_peering_auto_accept"></a> [peering\_auto\_accept](#input\_peering\_auto\_accept) | Set true to enable auto-accept in an AWS account. | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region where the requester-side resources are created. When null, uses the provider's configured region. Distinct from `peer_region`, which is the region of the peer VPC. | `string` | `null` | no |
 | <a name="input_requester_vpc_id"></a> [requester\_vpc\_id](#input\_requester\_vpc\_id) | Requester VPC ID filter | `string` | `""` | no |
 | <a name="input_requester_vpc_tags"></a> [requester\_vpc\_tags](#input\_requester\_vpc\_tags) | Requester VPC Tags filter | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{"BusinessUnit" = "XYZ"`) | `map(string)` | `{}` | no |

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -9,12 +9,15 @@
 * Users of this module need to set up the accepter side in other means, by accepting the VPC peering connection and
 * set up the route to the requester.
 *
+* `region` specifies where the requester-side resources are created; `peer_region` is the region the
+* peer VPC resides in and is passed to `aws_vpc_peering_connection.peer_region`.
+*
 * ## Usage Example
 *
 *
 * ```hcl
 * module "peering-request" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v2.3.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v3.0.0"
 *
 *   enabled              = "true"
 *   namespace            = "foo"
@@ -24,14 +27,11 @@
 *   requester_vpc_id     = "vpc-12345678"
 *   peer_owner_id        = "012345678901"
 *   peer_vpc_id          = "vpc-0123456789abcdef"
+*   region               = "us-east-1"
 *   peer_region          = "us-west-1"
 *   peer_vpc_cidr_blocks = ["192.0.2.0/24"]
 *   tags {
 *     Environment = "development"
-*   }
-*
-*   providers = {
-*     aws = aws.us-east-1
 *   }
 * }
 * ```
@@ -40,14 +40,4 @@
 locals {
   enabled = var.enabled == "true"
   count   = local.enabled ? 1 : 0
-}
-
-terraform {
-  required_version = ">= 0.13"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2"
-    }
-  }
 }

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -17,7 +17,9 @@
 *
 * ```hcl
 * module "peering-request" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v3.0.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=10.0.0"
+*
+*   region = "us-east-1"
 *
 *   enabled              = "true"
 *   namespace            = "foo"
@@ -27,7 +29,6 @@
 *   requester_vpc_id     = "vpc-12345678"
 *   peer_owner_id        = "012345678901"
 *   peer_vpc_id          = "vpc-0123456789abcdef"
-*   region               = "us-east-1"
 *   peer_region          = "us-west-1"
 *   peer_vpc_cidr_blocks = ["192.0.2.0/24"]
 *   tags {

--- a/aws/vpc-peering-requester-multiaccount/main.tf
+++ b/aws/vpc-peering-requester-multiaccount/main.tf
@@ -17,7 +17,7 @@
 *
 * ```hcl
 * module "peering-request" {
-*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=10.0.0"
+*   source = "github.com/elastic-infra/terraform-modules//aws/vpc-peering-requester-multiaccount?ref=v10.0.0"
 *
 *   region = "us-east-1"
 *

--- a/aws/vpc-peering-requester-multiaccount/requester.tf
+++ b/aws/vpc-peering-requester-multiaccount/requester.tf
@@ -19,13 +19,19 @@ module "requester_label" {
 # Lookup requester VPC so that we can reference the CIDR
 data "aws_vpc" "requester" {
   count = local.count
-  id    = var.requester_vpc_id
-  tags  = var.requester_vpc_tags
+
+  region = var.region
+
+  id   = var.requester_vpc_id
+  tags = var.requester_vpc_tags
 }
 
 # Lookup requester subnets
 data "aws_subnets" "requester" {
   count = local.count
+
+  region = var.region
+
   filter {
     name   = "vpc-id"
     values = [local.requester_vpc_id]
@@ -40,12 +46,18 @@ locals {
 
 # Lookup requester route tables
 data "aws_route_table" "requester" {
-  count     = local.enabled ? local.requester_subnet_ids_count : 0
+  count = local.enabled ? local.requester_subnet_ids_count : 0
+
+  region = var.region
+
   subnet_id = element(local.requester_subnet_ids, count.index)
 }
 
 resource "aws_vpc_peering_connection" "requester" {
-  count         = local.count
+  count = local.count
+
+  region = var.region
+
   vpc_id        = local.requester_vpc_id
   peer_vpc_id   = var.peer_vpc_id
   peer_owner_id = var.peer_owner_id
@@ -65,7 +77,10 @@ locals {
 
 # Create routes from requester to accepter
 resource "aws_route" "requester" {
-  count                     = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
+  count = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
+
+  region = var.region
+
   route_table_id            = element(local.requester_aws_route_table_ids, ceil(count.index / local.accepter_cidr_block_associations_count))
   destination_cidr_block    = element(var.peer_vpc_cidr_blocks, count.index % local.accepter_cidr_block_associations_count)
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.requester.*.id)

--- a/aws/vpc-peering-requester-multiaccount/variables.tf
+++ b/aws/vpc-peering-requester-multiaccount/variables.tf
@@ -1,3 +1,9 @@
+variable "region" {
+  type        = string
+  default     = null
+  description = "AWS region where the requester-side resources are created. When null, uses the provider's configured region. Distinct from `peer_region`, which is the region of the peer VPC."
+}
+
 variable "enabled" {
   default     = "true"
   type        = string

--- a/aws/vpc-peering-requester-multiaccount/versions.tf
+++ b/aws/vpc-peering-requester-multiaccount/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `region` variable (default `null`) to both `vpc-peering-accepter-multiaccount` and `vpc-peering-requester-multiaccount`, propagating `region = var.region` to every `aws_*` resource and supported data source.
- Bump AWS provider constraint from `>= 2` to `>= 6.0` and split the version constraints out of `main.tf` into a dedicated `versions.tf`.
- Drop the `providers = { aws = aws.us-east-1 }` snippet from each README's Usage Example in favor of passing `region = "us-east-1"` directly.

## Motivation

Callers that want to create peering resources in a non-default region currently need a provider alias and `providers = { aws = aws.foo }`. With the [v6 region attribute](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support), they can now pass `region = "us-east-1"` to the module directly.

## Breaking change

- Provider constraint is raised to `>= 6.0`; consumers still on AWS provider v5 or below must upgrade the provider before adopting this module version.
- Callers that do not set `var.region` see no behavioral change: `region = null` falls back to the default provider region.

## Notes

- In the requester module, the new `region` is distinct from the existing `peer_region`: `region` is where the requester-side resources are created, while `peer_region` is passed to `aws_vpc_peering_connection.peer_region` (the region of the peer VPC). Both can be set simultaneously for cross-region peering. The distinction is now documented in the module docstring and variable description.
- `data "aws_vpc_peering_connection"` does not accept a region argument (region is a computed attribute), so it is left as-is.
- READMEs regenerated via `make -f aws/tools/Makefile`.

## Test plan

- [x] `terraform init` + `terraform validate` on both modules — success
- [x] `terraform fmt` / `terraform-docs` via `make`
- [ ] Manual `terraform plan` in a real consumer state with `var.region` unset — expect no diff
- [ ] Manual `terraform plan` with `region = "us-east-2"` — expect resources targeted at us-east-2