### PR TITLE
feat(resolver-query-log-table): add new module for Route 53 Resolver query log

### DIFF
--- a/aws/resolver-query-log-table/README.md
+++ b/aws/resolver-query-log-table/README.md
@@ -1,0 +1,59 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Athena table for Route 53 Resolver query log
+
+Query logs are delivered as gzip-compressed JSON objects under
+`AWSLogs/<account-id>/vpcdnsquerylogs/<vpc-id>/YYYY/MM/DD/`. The last
+segment of `location` must be the target VPC id, so create one table
+per VPC.
+
+### Usage
+
+```hcl
+module "main" {
+  source = "github.com/elastic-infra/terraform-modules//aws/resolver-query-log-table?ref=vX.Y.Z"
+
+  name          = "main"
+  database_name = "resolverquerylog"
+  location      = "s3://${aws_s3_bucket.log.id}/AWSLogs/${data.aws_caller_identity.self.account_id}/vpcdnsquerylogs/${var.vpc_id}"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_glue_catalog_table.t](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | The s3 location of the Route 53 Resolver query log. The last segment must be the target VPC id. (ex: s3://resolver\_query\_log\_bucket/AWSLogs/<ACCOUNT-ID>/vpcdnsquerylogs/<VPC-ID>) | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the table. For Hive compatibility, this must be entirely lowercase. | `string` | n/a | yes |
+| <a name="input_partition_range"></a> [partition\_range](#input\_partition\_range) | A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types. | `string` | `"NOW-1MONTH,NOW"` | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/resolver-query-log-table/constraints.tf
+++ b/aws/resolver-query-log-table/constraints.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2"
+    }
+  }
+}

--- a/aws/resolver-query-log-table/main.tf
+++ b/aws/resolver-query-log-table/main.tf
@@ -1,0 +1,146 @@
+/**
+* ## Information
+*
+* Athena table for Route 53 Resolver query log
+*
+* Query logs are delivered as gzip-compressed JSON objects under
+* `AWSLogs/<account-id>/vpcdnsquerylogs/<vpc-id>/YYYY/MM/DD/`. The last
+* segment of `location` must be the target VPC id, so create one table
+* per VPC.
+*
+* ### Usage
+*
+* ```hcl
+* module "main" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/resolver-query-log-table?ref=vX.Y.Z"
+*
+*   name          = "main"
+*   database_name = "resolverquerylog"
+*   location      = "s3://${aws_s3_bucket.log.id}/AWSLogs/${data.aws_caller_identity.self.account_id}/vpcdnsquerylogs/${var.vpc_id}"
+* }
+* ```
+*
+*/
+
+resource "aws_glue_catalog_table" "t" {
+  name          = var.name
+  database_name = var.database_name
+
+  table_type = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL       = "TRUE"
+    classification = "json"
+    # NOTE: https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html
+    "projection.enabled"            = true
+    "projection.date.type"          = "date"
+    "projection.date.range"         = var.partition_range
+    "projection.date.format"        = "yyyy/MM/dd"
+    "projection.date.interval"      = 1
+    "projection.date.interval.unit" = "DAYS"
+    "storage.location.template"     = "${var.location}/$${date}"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+      parameters = {
+        "ignore.malformed.json" = "true"
+      }
+    }
+
+    columns {
+      name = "version"
+      type = "string"
+    }
+
+    columns {
+      name = "account_id"
+      type = "string"
+    }
+
+    columns {
+      name = "region"
+      type = "string"
+    }
+
+    columns {
+      name = "vpc_id"
+      type = "string"
+    }
+
+    columns {
+      name = "query_timestamp"
+      type = "string"
+    }
+
+    columns {
+      name = "query_name"
+      type = "string"
+    }
+
+    columns {
+      name = "query_type"
+      type = "string"
+    }
+
+    columns {
+      name = "query_class"
+      type = "string"
+    }
+
+    columns {
+      name = "rcode"
+      type = "string"
+    }
+
+    columns {
+      name = "answers"
+      type = "array<struct<Rdata:string,Type:string,Class:string>>"
+    }
+
+    columns {
+      name = "srcaddr"
+      type = "string"
+    }
+
+    columns {
+      name = "srcport"
+      type = "int"
+    }
+
+    columns {
+      name = "transport"
+      type = "string"
+    }
+
+    columns {
+      name = "srcids"
+      type = "struct<instance:string,resolver_endpoint:string,resolver_network_interface:string>"
+    }
+
+    columns {
+      name = "firewall_rule_group_id"
+      type = "string"
+    }
+
+    columns {
+      name = "firewall_rule_action"
+      type = "string"
+    }
+
+    columns {
+      name = "firewall_domain_list_id"
+      type = "string"
+    }
+  }
+
+  partition_keys {
+    name = "date"
+    type = "string"
+  }
+}

--- a/aws/resolver-query-log-table/variables.tf
+++ b/aws/resolver-query-log-table/variables.tf
@@ -1,0 +1,30 @@
+variable "name" {
+  type        = string
+  description = "Name of the table. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_]+$", var.name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "database_name" {
+  type        = string
+  description = "Name of the metadata database where the table metadata resides. For Hive compatibility, this must be entirely lowercase."
+
+  validation {
+    condition     = can(regex("^[0-9a-z_-]+$", var.database_name))
+    error_message = "The name value must be entirely lowercase."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "The s3 location of the Route 53 Resolver query log. The last segment must be the target VPC id. (ex: s3://resolver_query_log_bucket/AWSLogs/<ACCOUNT-ID>/vpcdnsquerylogs/<VPC-ID>)"
+}
+
+variable "partition_range" {
+  type        = string
+  description = "A two-element, comma-separated list which provides the minimum and maximum range values. These values are inclusive and can use any format compatible with the Java `java.time.*` date types."
+  default     = "NOW-1MONTH,NOW"
+}


### PR DESCRIPTION
## Summary

- Add new `aws/resolver-query-log-table` module that creates an Athena Glue Catalog Table over Route 53 Resolver VPC DNS query logs delivered to S3.
- Uses `org.openx.data.jsonserde.JsonSerDe` and partition projection on `date` (`yyyy/MM/dd`).
- One table per VPC, since query logs are partitioned by VPC id at the S3 prefix level.

## Motivation

Resolver query logs are delivered as gzip-compressed JSON under
`AWSLogs/<account-id>/vpcdnsquerylogs/<vpc-id>/YYYY/MM/DD/`.
This module creates a Glue Catalog Table that lets users query those
logs from Athena, complementing the existing `flow-log-table`,
`cloudtrail-table`, `cloudfront-log-table`, and `waf-log-table`
modules.

## Schema rationale

Column types and struct field names are determined from the following
authoritative sources:

1. [Values that appear in VPC Resolver query logs (Route53 Developer Guide)](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-query-logs-format.html) — field list and which fields are optional.
2. [Querying Route 53 Resolver logs (Athena User Guide)](https://docs.aws.amazon.com/athena/latest/ug/querying-r53-resolver-logs-creating-the-table.html) — official `CREATE EXTERNAL TABLE` example.
3. Verification against actual delivered log records.

Notable decisions:

- `srcport` is defined as `int`, matching the official Athena DDL
  example. Real log records emit `srcport` as a JSON-quoted string
  (e.g. `"35660"`), but openx JsonSerDe auto-coerces quoted numeric
  strings to numeric column types.
- `answers` struct field names are `Rdata` / `Type` / `Class`
  (leading-uppercase, matching both the actual JSON emitted by the
  Resolver service and the official DDL example).
- `srcids` is defined as a 3-field struct (`instance`,
  `resolver_endpoint`, `resolver_network_interface`). The official
  Athena DDL example only lists two of these fields, but the format
  documentation describes all three; openx JsonSerDe returns `null`
  for fields absent from the actual record, so defining all three
  is forward-compatible.

## Notes

- DNS Firewall fields (`firewall_rule_group_id`, `firewall_rule_action`, `firewall_domain_list_id`) are defined as optional `string` columns; they are populated only when a DNS Firewall rule matches.
- Partition projection uses only `date`; the S3 key layout has no hour-level segment.
- README generated via `make -f aws/tools/Makefile`.

## Test plan

- [x] `terraform init` + `terraform validate` — success
- [x] `terraform fmt` / `terraform-docs` via `make`
- [x] Manual `SELECT COUNT(*) FROM <table>` and `SHOW PARTITIONS <table>` in a real consumer state — confirm rows are queryable