### PR TITLE
feat(private-s3-bucket): support account-regional bucket namespace

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -31,7 +31,7 @@ module "bucket" {
 
   bucket_name      = "my-bucket"
   bucket_namespace = "account-regional"
-  # => actual bucket name: "my-bucket-{account_id}-{region}"
+  # => actual bucket name: "my-bucket-{account_id}-{region}-an"
 }
 ```
 

--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -23,6 +23,18 @@ module "bucket" {
 }
 ```
 
+#### Account-Regional Namespace
+
+```hcl
+module "bucket" {
+  source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vX.X.X"
+
+  bucket_name      = "my-bucket"
+  bucket_namespace = "account-regional"
+  # => actual bucket name: "my-bucket-{account_id}-{region}"
+}
+```
+
 ### Complex Inputs
 
 #### grant
@@ -195,13 +207,13 @@ data "aws_iam_policy_document" "example_bucket_policy" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.37.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.37.0 |
 
 ## Modules
 
@@ -222,14 +234,17 @@ No modules.
 | [aws_s3_bucket_public_access_block.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
 | [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | S3 bucket name | `string` | n/a | yes |
+| <a name="input_bucket_namespace"></a> [bucket\_namespace](#input\_bucket\_namespace) | Namespace for the bucket. Valid values: "account-regional", "global". Defaults to null (global). | `string` | `null` | no |
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | Bucket policy to be merged with SSL-only policy. You can only set this when manage\_bucket\_policy is true. | `string` | `null` | no |
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | S3 CORS headers | <pre>list(object({<br/>    allowed_headers = list(string)<br/>    allowed_methods = list(string)<br/>    allowed_origins = list(string)<br/>    expose_headers  = list(string)<br/>    max_age_seconds = number<br/>  }))</pre> | `[]` | no |
 | <a name="input_disable_private"></a> [disable\_private](#input\_disable\_private) | If true, disable private bucket feature | `bool` | `false` | no |

--- a/aws/private-s3-bucket/constraints.tf
+++ b/aws/private-s3-bucket/constraints.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0"
+      version = ">= 6.37.0"
     }
   }
 }

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -214,7 +214,7 @@ data "aws_region" "current" {}
 locals {
   block_access_enabled = !var.disable_private
   object_ownership     = coalesce(var.object_ownership, length(var.grant) > 0 ? "ObjectWriter" : "BucketOwnerEnforced")
-  effective_region     = coalesce(var.region, data.aws_region.current.name)
+  effective_region     = coalesce(var.region, data.aws_region.current.region)
   actual_bucket_name = (
     var.bucket_namespace == "account-regional"
     ? format("%s-%s-%s-an", var.bucket_name, data.aws_caller_identity.current.account_id, local.effective_region)

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -23,6 +23,18 @@
 * }
 * ```
 *
+* #### Account-Regional Namespace
+*
+* ```hcl
+* module "bucket" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vX.X.X"
+*
+*   bucket_name      = "my-bucket"
+*   bucket_namespace = "account-regional"
+*   # => actual bucket name: "my-bucket-{account_id}-{region}"
+* }
+* ```
+*
 * ### Complex Inputs
 *
 * #### grant
@@ -195,16 +207,27 @@
 # For "grant"
 data "aws_canonical_user_id" "current" {}
 
+# For "bucket_namespace"
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 locals {
   block_access_enabled = !var.disable_private
   object_ownership     = coalesce(var.object_ownership, length(var.grant) > 0 ? "ObjectWriter" : "BucketOwnerEnforced")
+  effective_region     = coalesce(var.region, data.aws_region.current.name)
+  actual_bucket_name = (
+    var.bucket_namespace == "account-regional"
+    ? format("%s-%s-%s", var.bucket_name, data.aws_caller_identity.current.account_id, local.effective_region)
+    : var.bucket_name
+  )
 }
 
 resource "aws_s3_bucket" "b" {
   region = var.region
 
-  bucket = var.bucket_name
-  tags   = var.tags
+  bucket           = local.actual_bucket_name
+  bucket_namespace = var.bucket_namespace
+  tags             = var.tags
 
   force_destroy = var.force_destroy
 }

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -31,7 +31,7 @@
 *
 *   bucket_name      = "my-bucket"
 *   bucket_namespace = "account-regional"
-*   # => actual bucket name: "my-bucket-{account_id}-{region}"
+*   # => actual bucket name: "my-bucket-{account_id}-{region}-an"
 * }
 * ```
 *
@@ -217,7 +217,7 @@ locals {
   effective_region     = coalesce(var.region, data.aws_region.current.name)
   actual_bucket_name = (
     var.bucket_namespace == "account-regional"
-    ? format("%s-%s-%s", var.bucket_name, data.aws_caller_identity.current.account_id, local.effective_region)
+    ? format("%s-%s-%s-an", var.bucket_name, data.aws_caller_identity.current.account_id, local.effective_region)
     : var.bucket_name
   )
 }

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -151,6 +151,17 @@ variable "object_lock_configuration" {
   }
 }
 
+variable "bucket_namespace" {
+  type        = string
+  description = "Namespace for the bucket. Valid values: \"account-regional\", \"global\". Defaults to null (global)."
+  default     = null
+
+  validation {
+    condition     = var.bucket_namespace == null || contains(["account-regional", "global"], var.bucket_namespace)
+    error_message = "Valid values are \"account-regional\" and \"global\"."
+  }
+}
+
 variable "manage_bucket_policy" {
   type        = bool
   description = "Whether to manage bucket policy in this module."


### PR DESCRIPTION
## Summary

Add S3 account-regional bucket namespace support to the `private-s3-bucket` module.

## Changes

- Add `bucket_namespace` variable (`"account-regional"` / `"global"` / `null`)
- When `bucket_namespace = "account-regional"`, the module automatically constructs the bucket name in `{bucket_name}-{account_id}-{region}-an` format using `data.aws_caller_identity` and `data.aws_region`
- If `var.region` is specified, it takes precedence; otherwise the provider's region is used
- Bump AWS provider version constraint from `>= 6.0` to `>= 6.37.0`
  - The `bucket_namespace` argument was introduced in AWS provider v6.37.0

## Changed resources

- `aws/private-s3-bucket/variables.tf` — Add `bucket_namespace` variable
- `aws/private-s3-bucket/main.tf` — Add data sources, locals, update `aws_s3_bucket.b`, update docs
- `aws/private-s3-bucket/constraints.tf` — Update AWS provider version constraint
- `aws/private-s3-bucket/README.md` — Regenerated with terraform-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)