### PR TITLE
feat: add devops-agent modules (monitor + source-role-stackset)

### DIFF
--- a/aws/devops-agent-monitor/README.md
+++ b/aws/devops-agent-monitor/README.md
@@ -68,9 +68,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_agent_space_name"></a> [agent\_space\_name](#input\_agent\_space\_name) | Name of the AWS DevOps Agent Agent Space. Must be unique within the account/region. | `string` | n/a | yes |
 | <a name="input_agent_space_description"></a> [agent\_space\_description](#input\_agent\_space\_description) | Description of the Agent Space. | `string` | `""` | no |
-| <a name="input_agent_space_managed_policy_arn"></a> [agent\_space\_managed\_policy\_arn](#input\_agent\_space\_managed\_policy\_arn) | AWS managed policy attached to the Agent Space role. | `string` | `"arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"` | no |
+| <a name="input_agent_space_managed_policy_arns"></a> [agent\_space\_managed\_policy\_arns](#input\_agent\_space\_managed\_policy\_arns) | AWS managed policy ARNs attached to the Agent Space role. | `list(string)` | <pre>[<br/>  "arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"<br/>]</pre> | no |
 | <a name="input_agent_space_role_name"></a> [agent\_space\_role\_name](#input\_agent\_space\_role\_name) | IAM role name assumed by the Agent Space (aidevops.amazonaws.com). Defaults to DevOpsAgent-<agent\_space\_name>-Space. | `string` | `null` | no |
-| <a name="input_operator_managed_policy_arn"></a> [operator\_managed\_policy\_arn](#input\_operator\_managed\_policy\_arn) | AWS managed policy attached to the Operator role. | `string` | `"arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"` | no |
+| <a name="input_operator_managed_policy_arns"></a> [operator\_managed\_policy\_arns](#input\_operator\_managed\_policy\_arns) | AWS managed policy ARNs attached to the Operator role. | `list(string)` | <pre>[<br/>  "arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"<br/>]</pre> | no |
 | <a name="input_operator_role_name"></a> [operator\_role\_name](#input\_operator\_role\_name) | IAM role name assumed by the Operator App. Defaults to DevOpsAgent-<agent\_space\_name>-WebappAdmin. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the IAM roles created by this module. | `map(string)` | `{}` | no |
 

--- a/aws/devops-agent-monitor/README.md
+++ b/aws/devops-agent-monitor/README.md
@@ -1,0 +1,87 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Provisions resources on the AWS DevOps Agent Monitoring (admin) account side.
+Creates a single Agent Space, two associated IAM roles (Agent Space / Operator App),
+and an Association that registers the Monitoring account itself as primary (monitor).
+
+Instantiate this module multiple times to isolate workloads into separate Agent Spaces.
+
+### Prerequisites
+
+- awscc >= 1.66
+- Supported regions: us-east-1, us-west-2, ap-southeast-2,
+  ap-northeast-1, eu-central-1, eu-west-1
+- IAM Identity Center is enabled in the account (required by Operator App)
+
+### Usage
+
+```hcl
+module "devops_agent_monitor" {
+  source = "github.com/elastic-infra/terraform-modules//aws/devops-agent-monitor?ref=v1.0.0"
+
+  agent_space_name        = "my-agent-space"
+  agent_space_description = "AgentSpace for production workload"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.29 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 1.66 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.44.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.83.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.agent_space](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.operator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policies_exclusive.agent_space_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policies_exclusive) | resource |
+| [aws_iam_role_policy.agent_space_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachments_exclusive.agent_space_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_iam_role_policy_attachments_exclusive.operator_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [awscc_devopsagent_agent_space.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/devopsagent_agent_space) | resource |
+| [awscc_devopsagent_association.primary](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/devopsagent_association) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.agent_space_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.agent_space_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.operator_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_agent_space_name"></a> [agent\_space\_name](#input\_agent\_space\_name) | Name of the AWS DevOps Agent Agent Space. Must be unique within the account/region. | `string` | n/a | yes |
+| <a name="input_agent_space_description"></a> [agent\_space\_description](#input\_agent\_space\_description) | Description of the Agent Space. | `string` | `""` | no |
+| <a name="input_agent_space_managed_policy_arn"></a> [agent\_space\_managed\_policy\_arn](#input\_agent\_space\_managed\_policy\_arn) | AWS managed policy attached to the Agent Space role. | `string` | `"arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"` | no |
+| <a name="input_agent_space_role_name"></a> [agent\_space\_role\_name](#input\_agent\_space\_role\_name) | IAM role name assumed by the Agent Space (aidevops.amazonaws.com). Defaults to DevOpsAgent-<agent\_space\_name>-Space. | `string` | `null` | no |
+| <a name="input_operator_managed_policy_arn"></a> [operator\_managed\_policy\_arn](#input\_operator\_managed\_policy\_arn) | AWS managed policy attached to the Operator role. | `string` | `"arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"` | no |
+| <a name="input_operator_role_name"></a> [operator\_role\_name](#input\_operator\_role\_name) | IAM role name assumed by the Operator App. Defaults to DevOpsAgent-<agent\_space\_name>-WebappAdmin. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the IAM roles created by this module. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_agent_space_arn"></a> [agent\_space\_arn](#output\_agent\_space\_arn) | ARN of the created Agent Space. |
+| <a name="output_agent_space_id"></a> [agent\_space\_id](#output\_agent\_space\_id) | ID of the created Agent Space. |
+| <a name="output_agent_space_name"></a> [agent\_space\_name](#output\_agent\_space\_name) | Name of the created Agent Space. |
+| <a name="output_agent_space_role_arn"></a> [agent\_space\_role\_arn](#output\_agent\_space\_role\_arn) | ARN of the IAM role assumed by the Agent Space (primary monitor association uses this). |
+| <a name="output_operator_role_arn"></a> [operator\_role\_arn](#output\_operator\_role\_arn) | ARN of the IAM role assumed by the Operator App. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/devops-agent-monitor/agent_space.tf
+++ b/aws/devops-agent-monitor/agent_space.tf
@@ -1,0 +1,30 @@
+resource "awscc_devopsagent_agent_space" "this" {
+  name        = var.agent_space_name
+  description = var.agent_space_description
+
+  operator_app = {
+    iam = {
+      operator_app_role_arn = aws_iam_role.operator.arn
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachments_exclusive.agent_space_managed,
+    aws_iam_role_policies_exclusive.agent_space_inline,
+    aws_iam_role_policy_attachments_exclusive.operator_managed,
+  ]
+}
+
+resource "awscc_devopsagent_association" "primary" {
+  agent_space_id = awscc_devopsagent_agent_space.this.id
+  service_id     = "aws"
+
+  configuration = {
+    aws = {
+      assumable_role_arn = aws_iam_role.agent_space.arn
+      account_id         = data.aws_caller_identity.current.account_id
+      account_type       = "monitor"
+      resources          = []
+    }
+  }
+}

--- a/aws/devops-agent-monitor/iam.tf
+++ b/aws/devops-agent-monitor/iam.tf
@@ -1,0 +1,102 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  agent_space_role_name   = coalesce(var.agent_space_role_name, "DevOpsAgent-${var.agent_space_name}-Space")
+  operator_role_name      = coalesce(var.operator_role_name, "DevOpsAgent-${var.agent_space_name}-WebappAdmin")
+  agent_space_arn_pattern = "arn:aws:aidevops:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agentspace/*"
+}
+
+data "aws_iam_policy_document" "agent_space_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["aidevops.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [local.agent_space_arn_pattern]
+    }
+  }
+}
+
+resource "aws_iam_role" "agent_space" {
+  name               = local.agent_space_role_name
+  description        = "Role assumed by AWS DevOps Agent Agent Space"
+  assume_role_policy = data.aws_iam_policy_document.agent_space_trust.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "agent_space_managed" {
+  role_name   = aws_iam_role.agent_space.name
+  policy_arns = [var.agent_space_managed_policy_arn]
+}
+
+data "aws_iam_policy_document" "agent_space_inline" {
+  statement {
+    sid     = "AllowCreateServiceLinkedRoles"
+    effect  = "Allow"
+    actions = ["iam:CreateServiceLinkedRole"]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "agent_space_inline" {
+  name   = "AllowCreateServiceLinkedRoles"
+  role   = aws_iam_role.agent_space.id
+  policy = data.aws_iam_policy_document.agent_space_inline.json
+}
+
+resource "aws_iam_role_policies_exclusive" "agent_space_inline" {
+  role_name    = aws_iam_role.agent_space.name
+  policy_names = [aws_iam_role_policy.agent_space_inline.name]
+}
+
+data "aws_iam_policy_document" "operator_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["aidevops.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [local.agent_space_arn_pattern]
+    }
+  }
+}
+
+resource "aws_iam_role" "operator" {
+  name               = local.operator_role_name
+  description        = "Role assumed by AWS DevOps Agent Operator App"
+  assume_role_policy = data.aws_iam_policy_document.operator_trust.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "operator_managed" {
+  role_name   = aws_iam_role.operator.name
+  policy_arns = [var.operator_managed_policy_arn]
+}

--- a/aws/devops-agent-monitor/iam.tf
+++ b/aws/devops-agent-monitor/iam.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role" "agent_space" {
 
 resource "aws_iam_role_policy_attachments_exclusive" "agent_space_managed" {
   role_name   = aws_iam_role.agent_space.name
-  policy_arns = [var.agent_space_managed_policy_arn]
+  policy_arns = var.agent_space_managed_policy_arns
 }
 
 data "aws_iam_policy_document" "agent_space_inline" {
@@ -98,5 +98,5 @@ resource "aws_iam_role" "operator" {
 
 resource "aws_iam_role_policy_attachments_exclusive" "operator_managed" {
   role_name   = aws_iam_role.operator.name
-  policy_arns = [var.operator_managed_policy_arn]
+  policy_arns = var.operator_managed_policy_arns
 }

--- a/aws/devops-agent-monitor/main.tf
+++ b/aws/devops-agent-monitor/main.tf
@@ -1,0 +1,28 @@
+/**
+* ## Information
+*
+* Provisions resources on the AWS DevOps Agent Monitoring (admin) account side.
+* Creates a single Agent Space, two associated IAM roles (Agent Space / Operator App),
+* and an Association that registers the Monitoring account itself as primary (monitor).
+*
+* Instantiate this module multiple times to isolate workloads into separate Agent Spaces.
+*
+* ### Prerequisites
+*
+* - awscc >= 1.66
+* - Supported regions: us-east-1, us-west-2, ap-southeast-2,
+*   ap-northeast-1, eu-central-1, eu-west-1
+* - IAM Identity Center is enabled in the account (required by Operator App)
+*
+* ### Usage
+*
+* ```hcl
+* module "devops_agent_monitor" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/devops-agent-monitor?ref=v1.0.0"
+*
+*   agent_space_name        = "my-agent-space"
+*   agent_space_description = "AgentSpace for production workload"
+* }
+* ```
+*
+*/

--- a/aws/devops-agent-monitor/outputs.tf
+++ b/aws/devops-agent-monitor/outputs.tf
@@ -1,0 +1,24 @@
+output "agent_space_id" {
+  description = "ID of the created Agent Space."
+  value       = awscc_devopsagent_agent_space.this.id
+}
+
+output "agent_space_arn" {
+  description = "ARN of the created Agent Space."
+  value       = awscc_devopsagent_agent_space.this.arn
+}
+
+output "agent_space_name" {
+  description = "Name of the created Agent Space."
+  value       = awscc_devopsagent_agent_space.this.name
+}
+
+output "agent_space_role_arn" {
+  description = "ARN of the IAM role assumed by the Agent Space (primary monitor association uses this)."
+  value       = aws_iam_role.agent_space.arn
+}
+
+output "operator_role_arn" {
+  description = "ARN of the IAM role assumed by the Operator App."
+  value       = aws_iam_role.operator.arn
+}

--- a/aws/devops-agent-monitor/variables.tf
+++ b/aws/devops-agent-monitor/variables.tf
@@ -1,0 +1,40 @@
+variable "agent_space_name" {
+  description = "Name of the AWS DevOps Agent Agent Space. Must be unique within the account/region."
+  type        = string
+}
+
+variable "agent_space_description" {
+  description = "Description of the Agent Space."
+  type        = string
+  default     = ""
+}
+
+variable "agent_space_role_name" {
+  description = "IAM role name assumed by the Agent Space (aidevops.amazonaws.com). Defaults to DevOpsAgent-<agent_space_name>-Space."
+  type        = string
+  default     = null
+}
+
+variable "operator_role_name" {
+  description = "IAM role name assumed by the Operator App. Defaults to DevOpsAgent-<agent_space_name>-WebappAdmin."
+  type        = string
+  default     = null
+}
+
+variable "agent_space_managed_policy_arn" {
+  description = "AWS managed policy attached to the Agent Space role."
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"
+}
+
+variable "operator_managed_policy_arn" {
+  description = "AWS managed policy attached to the Operator role."
+  type        = string
+  default     = "arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"
+}
+
+variable "tags" {
+  description = "Tags applied to the IAM roles created by this module."
+  type        = map(string)
+  default     = {}
+}

--- a/aws/devops-agent-monitor/variables.tf
+++ b/aws/devops-agent-monitor/variables.tf
@@ -21,16 +21,16 @@ variable "operator_role_name" {
   default     = null
 }
 
-variable "agent_space_managed_policy_arn" {
-  description = "AWS managed policy attached to the Agent Space role."
-  type        = string
-  default     = "arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"
+variable "agent_space_managed_policy_arns" {
+  description = "AWS managed policy ARNs attached to the Agent Space role."
+  type        = list(string)
+  default     = ["arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy"]
 }
 
-variable "operator_managed_policy_arn" {
-  description = "AWS managed policy attached to the Operator role."
-  type        = string
-  default     = "arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"
+variable "operator_managed_policy_arns" {
+  description = "AWS managed policy ARNs attached to the Operator role."
+  type        = list(string)
+  default     = ["arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy"]
 }
 
 variable "tags" {

--- a/aws/devops-agent-monitor/versions.tf
+++ b/aws/devops-agent-monitor/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.29"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.66"
+    }
+  }
+}

--- a/aws/devops-agent-source-role-stackset/README.md
+++ b/aws/devops-agent-source-role-stackset/README.md
@@ -1,0 +1,85 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Information
+
+Distributes the AWS DevOps Agent Source Role to AWS Organizations member
+accounts via a service-managed CloudFormation StackSet.
+
+### Prerequisites
+
+- The calling account must be a registered CloudFormation StackSets delegated
+  administrator. This module always sets `call_as = "DELEGATED_ADMIN"` and
+  does not support being invoked from the Organizations management account.
+- `stacksets.cloudformation.amazonaws.com` must be present in
+  `aws_organizations_organization.aws_service_access_principals`
+
+### Behavior
+
+- Distributes the same Source Role (default name: `AWSDevOpsAgentSourceRole`)
+  to every workload account under the configured OUs
+- Trust conditions: `aws:SourceAccount = <monitoring_account_id>` and
+  `aws:SourceArn ArnLike "arn:aws:aidevops:<monitoring_region>:<monitoring_account_id>:agentspace/*"`
+- Includes an inline policy that lets the role create the Resource Explorer
+  service-linked role on first investigation
+- The CloudFormation template receives monitoring identifiers via Parameters
+  so the template stays organization-agnostic
+
+### Usage
+
+```hcl
+module "devops_agent_source_role_stackset" {
+  source = "github.com/elastic-infra/terraform-modules//aws/devops-agent-source-role-stackset?ref=v1.0.0"
+
+  organizational_unit_ids = [
+    "ou-xxxx-aaaaaaaa", # production
+    "ou-xxxx-bbbbbbbb", # development
+  ]
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.29 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.44.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudformation_stack_instances.source_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_instances) | resource |
+| [aws_cloudformation_stack_set.source_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_organizational_unit_ids"></a> [organizational\_unit\_ids](#input\_organizational\_unit\_ids) | OU IDs to deploy AWSDevOpsAgentSourceRole to. The StackSet auto-deploys to all accounts under these OUs. | `list(string)` | n/a | yes |
+| <a name="input_managed_policy_name"></a> [managed\_policy\_name](#input\_managed\_policy\_name) | AWS managed policy name attached to the role. | `string` | `"AIDevOpsAgentAccessPolicy"` | no |
+| <a name="input_monitoring_account_id"></a> [monitoring\_account\_id](#input\_monitoring\_account\_id) | AWS DevOps Agent monitoring (admin) account id used in aws:SourceAccount trust condition. If null, the caller's account id is used. | `string` | `null` | no |
+| <a name="input_monitoring_region"></a> [monitoring\_region](#input\_monitoring\_region) | Region where the Agent Space is deployed. Used in aws:SourceArn ArnLike trust condition. | `string` | `"ap-northeast-1"` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | Regions in which StackSet instance metadata is recorded. The IAM role itself is global, so a single region is enough. | `list(string)` | <pre>[<br/>  "ap-northeast-1"<br/>]</pre> | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name created in each workload account. | `string` | `"AWSDevOpsAgentSourceRole"` | no |
+| <a name="input_stack_set_name"></a> [stack\_set\_name](#input\_stack\_set\_name) | Name of the CloudFormation StackSet. | `string` | `"AWSDevOpsAgentSourceRole"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags applied to the StackSet resource. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | IAM role name distributed to each workload account. |
+| <a name="output_stack_set_id"></a> [stack\_set\_id](#output\_stack\_set\_id) | ID of the CloudFormation StackSet. |
+| <a name="output_stack_set_name"></a> [stack\_set\_name](#output\_stack\_set\_name) | Name of the CloudFormation StackSet that distributes AWSDevOpsAgentSourceRole. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws/devops-agent-source-role-stackset/main.tf
+++ b/aws/devops-agent-source-role-stackset/main.tf
@@ -1,0 +1,39 @@
+/**
+* ## Information
+*
+* Distributes the AWS DevOps Agent Source Role to AWS Organizations member
+* accounts via a service-managed CloudFormation StackSet.
+*
+* ### Prerequisites
+*
+* - The calling account must be a registered CloudFormation StackSets delegated
+*   administrator. This module always sets `call_as = "DELEGATED_ADMIN"` and
+*   does not support being invoked from the Organizations management account.
+* - `stacksets.cloudformation.amazonaws.com` must be present in
+*   `aws_organizations_organization.aws_service_access_principals`
+*
+* ### Behavior
+*
+* - Distributes the same Source Role (default name: `AWSDevOpsAgentSourceRole`)
+*   to every workload account under the configured OUs
+* - Trust conditions: `aws:SourceAccount = <monitoring_account_id>` and
+*   `aws:SourceArn ArnLike "arn:aws:aidevops:<monitoring_region>:<monitoring_account_id>:agentspace/*"`
+* - Includes an inline policy that lets the role create the Resource Explorer
+*   service-linked role on first investigation
+* - The CloudFormation template receives monitoring identifiers via Parameters
+*   so the template stays organization-agnostic
+*
+* ### Usage
+*
+* ```hcl
+* module "devops_agent_source_role_stackset" {
+*   source = "github.com/elastic-infra/terraform-modules//aws/devops-agent-source-role-stackset?ref=v1.0.0"
+*
+*   organizational_unit_ids = [
+*     "ou-xxxx-aaaaaaaa", # production
+*     "ou-xxxx-bbbbbbbb", # development
+*   ]
+* }
+* ```
+*
+*/

--- a/aws/devops-agent-source-role-stackset/outputs.tf
+++ b/aws/devops-agent-source-role-stackset/outputs.tf
@@ -1,0 +1,14 @@
+output "stack_set_name" {
+  description = "Name of the CloudFormation StackSet that distributes AWSDevOpsAgentSourceRole."
+  value       = aws_cloudformation_stack_set.source_role.name
+}
+
+output "stack_set_id" {
+  description = "ID of the CloudFormation StackSet."
+  value       = aws_cloudformation_stack_set.source_role.stack_set_id
+}
+
+output "role_name" {
+  description = "IAM role name distributed to each workload account."
+  value       = var.role_name
+}

--- a/aws/devops-agent-source-role-stackset/stackset.tf
+++ b/aws/devops-agent-source-role-stackset/stackset.tf
@@ -1,0 +1,44 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  effective_monitoring_account_id = coalesce(var.monitoring_account_id, data.aws_caller_identity.current.account_id)
+}
+
+resource "aws_cloudformation_stack_set" "source_role" {
+  name             = var.stack_set_name
+  description      = "Deploy AWSDevOpsAgentSourceRole to organization accounts"
+  permission_model = "SERVICE_MANAGED"
+  capabilities     = ["CAPABILITY_NAMED_IAM"]
+  call_as          = "DELEGATED_ADMIN"
+
+  template_body = file("${path.module}/templates/source-role.yaml")
+
+  parameters = {
+    MonitoringAccountId = local.effective_monitoring_account_id
+    MonitoringRegion    = var.monitoring_region
+    RoleName            = var.role_name
+    ManagedPolicyName   = var.managed_policy_name
+  }
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  managed_execution {
+    active = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudformation_stack_instances" "source_role" {
+  stack_set_name = aws_cloudformation_stack_set.source_role.name
+  call_as        = "DELEGATED_ADMIN"
+
+  deployment_targets {
+    organizational_unit_ids = var.organizational_unit_ids
+  }
+
+  regions = var.regions
+}

--- a/aws/devops-agent-source-role-stackset/templates/source-role.yaml
+++ b/aws/devops-agent-source-role-stackset/templates/source-role.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: AWS DevOps Agent Source Role (deployed via service-managed StackSet)
+
+Parameters:
+  MonitoringAccountId:
+    Type: String
+    Description: AWS DevOps Agent monitoring account id that workload accounts trust.
+    AllowedPattern: "^[0-9]{12}$"
+  MonitoringRegion:
+    Type: String
+    Description: Region in which the AWS DevOps Agent Agent Space lives. Used in aws:SourceArn condition.
+    Default: ap-northeast-1
+  RoleName:
+    Type: String
+    Default: AWSDevOpsAgentSourceRole
+  ManagedPolicyName:
+    Type: String
+    Default: AIDevOpsAgentAccessPolicy
+
+Resources:
+  SourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: Cross-account role assumed by AWS DevOps Agent monitoring account.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: aidevops.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref MonitoringAccountId
+              ArnLike:
+                aws:SourceArn: !Sub "arn:aws:aidevops:${MonitoringRegion}:${MonitoringAccountId}:agentspace/*"
+      ManagedPolicyArns:
+        - !Sub "arn:aws:iam::aws:policy/${ManagedPolicyName}"
+      Policies:
+        - PolicyName: AllowCreateServiceLinkedRoles
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: AllowCreateResourceExplorerSLR
+                Effect: Allow
+                Action: iam:CreateServiceLinkedRole
+                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer"

--- a/aws/devops-agent-source-role-stackset/variables.tf
+++ b/aws/devops-agent-source-role-stackset/variables.tf
@@ -1,0 +1,46 @@
+variable "organizational_unit_ids" {
+  description = "OU IDs to deploy AWSDevOpsAgentSourceRole to. The StackSet auto-deploys to all accounts under these OUs."
+  type        = list(string)
+}
+
+variable "monitoring_account_id" {
+  description = "AWS DevOps Agent monitoring (admin) account id used in aws:SourceAccount trust condition. If null, the caller's account id is used."
+  type        = string
+  default     = null
+}
+
+variable "monitoring_region" {
+  description = "Region where the Agent Space is deployed. Used in aws:SourceArn ArnLike trust condition."
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "stack_set_name" {
+  description = "Name of the CloudFormation StackSet."
+  type        = string
+  default     = "AWSDevOpsAgentSourceRole"
+}
+
+variable "role_name" {
+  description = "IAM role name created in each workload account."
+  type        = string
+  default     = "AWSDevOpsAgentSourceRole"
+}
+
+variable "managed_policy_name" {
+  description = "AWS managed policy name attached to the role."
+  type        = string
+  default     = "AIDevOpsAgentAccessPolicy"
+}
+
+variable "regions" {
+  description = "Regions in which StackSet instance metadata is recorded. The IAM role itself is global, so a single region is enough."
+  type        = list(string)
+  default     = ["ap-northeast-1"]
+}
+
+variable "tags" {
+  description = "Tags applied to the StackSet resource."
+  type        = map(string)
+  default     = {}
+}

--- a/aws/devops-agent-source-role-stackset/versions.tf
+++ b/aws/devops-agent-source-role-stackset/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.29"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add two new Terraform modules for AWS DevOps Agent:

- `aws/devops-agent-monitor` — Provisions an Agent Space on the monitoring (admin) account, along with the AgentSpace IAM role, the Operator App IAM role, and the primary (monitor) account association.
- `aws/devops-agent-source-role-stackset` — Distributes the cross-account Source Role to every member account under the configured AWS Organizations OUs via a service-managed CloudFormation StackSet.

These modules are based on AWS' official Terraform sample at <https://github.com/aws-samples/sample-aws-devops-agent-terraform> and have been reviewed internally before being proposed here.

## `devops-agent-monitor`

- `awscc_devopsagent_agent_space` with `operator_app.iam.operator_app_role_arn`
- AgentSpace IAM role: trust = `aidevops.amazonaws.com` + `aws:SourceAccount` + `aws:SourceArn ArnLike agentspace/*`, with the `AIDevOpsAgentAccessPolicy` managed policy and an inline policy that allows `iam:CreateServiceLinkedRole` on the Resource Explorer SLR
- Operator IAM role: trust includes `sts:TagSession` so the DevOps Agent Web App backend can forward operator session tags
- `awscc_devopsagent_association` registering the monitoring account as primary

Both roles use `aws_iam_role_policy_attachments_exclusive` and (for the AgentSpace role) `aws_iam_role_policies_exclusive` so any out-of-band attachments are reverted by Terraform, matching the semantics of the existing `iam-service-role` module.

`aws_iam_role` is declared directly (rather than via `iam-service-role`) because the trust policy requires `aws:SourceAccount` + `aws:SourceArn` conditions that `iam-service-role` does not support — the same pattern already used by `aws/datadog-role`, `aws/grafana-role`, and `aws/rdsmonitor-role`.

## `devops-agent-source-role-stackset`

- `aws_cloudformation_stack_set` with `permission_model = SERVICE_MANAGED` and `auto_deployment.enabled = true`
- `aws_cloudformation_stack_instances` (plural) targets the configured OUs across one or more regions in a single resource
- CloudFormation template parameterised via `MonitoringAccountId` / `MonitoringRegion` / `RoleName` / `ManagedPolicyName`, so the template itself stays organisation-agnostic
- The distributed IAM role has the same trust constraints and inline policy as the AgentSpace role in `devops-agent-monitor`
- `call_as` is hard-coded to `DELEGATED_ADMIN`. The module must be invoked from a registered StackSets delegated administrator account (not from the Organizations management account); this constraint is documented in the module's Prerequisites section.

## Required provider versions

- `awscc >= 1.66`
- `aws >= 6.29` (relies on the fix from hashicorp/terraform-provider-aws#45992 for `administration_role_arn` drift on SERVICE_MANAGED StackSets)

## Verification

- [x] `terraform fmt`
- [x] `terraform validate` (both modules, with `awscc` 1.83.x / `aws` 6.43.x)
- [x] `cfn-lint` clean for `aws/devops-agent-source-role-stackset/templates/source-role.yaml`
- [x] README generated via `terraform-docs`

## References

- [AWS DevOps Agent — Terraform getting started](https://docs.aws.amazon.com/devopsagent/latest/userguide/getting-started-with-aws-devops-agent-getting-started-with-aws-devops-agent-using-terraform.html)
- [aws-samples/sample-aws-devops-agent-terraform](https://github.com/aws-samples/sample-aws-devops-agent-terraform)