### PR TITLE
fix(devops-agent-monitor): remove resources = [] to avoid perpetual diff

### DIFF
--- a/aws/devops-agent-monitor/agent_space.tf
+++ b/aws/devops-agent-monitor/agent_space.tf
@@ -24,7 +24,6 @@ resource "awscc_devopsagent_association" "primary" {
       assumable_role_arn = aws_iam_role.agent_space.arn
       account_id         = data.aws_caller_identity.current.account_id
       account_type       = "monitor"
-      resources          = []
     }
   }
 }


### PR DESCRIPTION
## Summary

The monitor association in `devops-agent-monitor` had `resources = []` hard-coded, which causes a perpetual in-place update on every `terraform plan`:

\`\`\`
~ resource "awscc_devopsagent_association" "primary" {
    ~ configuration = {
        ~ aws = {
            + resources = []
              # (3 unchanged attributes hidden)
          }
          ...
\`\`\`

## Cause

The `Resources` attribute on the monitor association configuration is declared as **Optional + Computed** in the awscc schema. When you pass an empty list `[]`, AWS persists it as `null` in the API response, so Terraform's next plan sees `[]` in config vs `null` in state and proposes an in-place update that never actually changes anything.

## Fix

Remove the `resources = []` line entirely. The attribute is optional and defaults to discovering all resources accessible by the role, which is the intended behaviour for a monitor association.

## Notes

- The AWS official sample at <https://github.com/aws-samples/sample-aws-devops-agent-terraform/blob/main/devops-agent.tf> still includes `resources = []` and exhibits the same drift. This fix is independent.
- No state surgery required for existing users; the next plan will simply stop proposing the no-op update.

## Verification

- [x] `terraform fmt`
- [x] `terraform validate`
- [ ] Verified locally that `terraform plan` is clean after switching the consuming root module to the fixed module version (will confirm once a tag is cut)

## Release

Suggest releasing as `v10.1.1` (patch on top of v10.1.0).