### PR TITLE
docs(github-oidc-provider): mark module as deprecated

### DIFF
--- a/aws/github-oidc-provider/README.md
+++ b/aws/github-oidc-provider/README.md
@@ -3,6 +3,21 @@
 
 Create OIDC provider for GitHub Actions
 
+**DEPRECATED**
+
+This module is deprecated and is no longer maintained.
+A plain `aws_iam_openid_connect_provider` resource is now sufficient: AWS verifies
+the GitHub IdP's TLS certificate against its trusted root CA store, so the hardcoded
+thumbprint list this module provides is no longer required. Define the resource
+directly instead:
+
+```hcl
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+}
+```
+
 ### Usage
 
 ```hcl

--- a/aws/github-oidc-provider/main.tf
+++ b/aws/github-oidc-provider/main.tf
@@ -3,6 +3,21 @@
 *
 * Create OIDC provider for GitHub Actions
 *
+* **DEPRECATED**
+*
+* This module is deprecated and is no longer maintained.
+* A plain `aws_iam_openid_connect_provider` resource is now sufficient: AWS verifies
+* the GitHub IdP's TLS certificate against its trusted root CA store, so the hardcoded
+* thumbprint list this module provides is no longer required. Define the resource
+* directly instead:
+*
+* ```hcl
+* resource "aws_iam_openid_connect_provider" "github_actions" {
+*   url            = "https://token.actions.githubusercontent.com"
+*   client_id_list = ["sts.amazonaws.com"]
+* }
+* ```
+*
 * ### Usage
 *
 * ```hcl


### PR DESCRIPTION
## Summary

Mark `aws/github-oidc-provider` as deprecated. The module's only value-add was hardcoding the GitHub IdP thumbprint, which is no longer necessary.

A plain `aws_iam_openid_connect_provider` resource is now sufficient:

```hcl
resource "aws_iam_openid_connect_provider" "github_actions" {
  url            = "https://token.actions.githubusercontent.com"
  client_id_list = ["sts.amazonaws.com"]
}
```

- AWS secures OIDC communication by verifying the JWKS endpoint's TLS certificate against its trusted root CA library; thumbprint verification is only a fallback for IdPs not signed by a trusted CA (or when TLS 1.3 is required). GitHub's `token.actions.githubusercontent.com` is covered by a trusted CA, so the hardcoded thumbprints no longer serve a security purpose. ([IAM docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html))
- `thumbprint_list` is optional; if omitted, IAM auto-retrieves the top intermediate CA thumbprint. ([AWS::IAM::OIDCProvider](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-iam-oidcprovider.html))

The module is not removed (it may still exist in external users' state); it is only marked deprecated so new usage is discouraged. The deprecation notice follows the existing pattern in `aws/private-s3-bucket`. README is regenerated via terraform-docs.

## Test plan

- [x] `terraform fmt -check` passes (no diff)
- [x] README regenerated; deprecation note appears under `## Information`, resource/output tables unchanged
- [x] `aws_iam_openid_connect_provider` resource body, outputs, and versions are unchanged (comment + README only)
