### PR TITLE
feat(private-s3-bucket): support bucket_key_enabled for SSE-KMS

### DIFF
--- a/aws/private-s3-bucket/README.md
+++ b/aws/private-s3-bucket/README.md
@@ -133,6 +133,14 @@ If you want to enable SSE-KMS, specify the KMS master key ID.
 sse_kms_master_key_id = "aws/s3" # or your CMK ID
 ```
 
+To reduce KMS request costs with SSE-KMS, enable an S3 Bucket Key.
+This can only be set together with `sse_kms_master_key_id`.
+
+```hcl
+sse_kms_master_key_id  = "aws/s3" # or your CMK ID
+sse_bucket_key_enabled = true
+```
+
 If you want to disable server side encryption, set disable\_sse as `true`.
 
 ```hcl
@@ -258,6 +266,7 @@ No modules.
 | <a name="input_object_lock_configuration"></a> [object\_lock\_configuration](#input\_object\_lock\_configuration) | S3 Object Lock Configuration. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | <pre>list(object({<br/>    rule = object({<br/>      default_retention = object({<br/>        mode  = string<br/>        days  = number<br/>        years = number<br/>      })<br/>    })<br/>  }))</pre> | `[]` | no |
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region where the bucket and its configurations are created. When null, uses the provider's configured region. | `string` | `null` | no |
+| <a name="input_sse_bucket_key_enabled"></a> [sse\_bucket\_key\_enabled](#input\_sse\_bucket\_key\_enabled) | Whether to use an Amazon S3 Bucket Key for SSE-KMS. Reduces KMS request costs. Can only be set when sse\_kms\_master\_key\_id is set. | `bool` | `null` | no |
 | <a name="input_sse_kms_master_key_id"></a> [sse\_kms\_master\_key\_id](#input\_sse\_kms\_master\_key\_id) | The AWS KMS master key ID used for the SSE-KMS encryption. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for S3 bucket | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | S3 object versioning settings | `bool` | `null` | no |

--- a/aws/private-s3-bucket/bucket_options.tf
+++ b/aws/private-s3-bucket/bucket_options.tf
@@ -161,6 +161,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "b" {
       kms_master_key_id = var.sse_kms_master_key_id
       sse_algorithm     = var.sse_kms_master_key_id == null ? "AES256" : "aws:kms"
     }
+    bucket_key_enabled = var.sse_bucket_key_enabled
   }
 }
 # CORS

--- a/aws/private-s3-bucket/main.tf
+++ b/aws/private-s3-bucket/main.tf
@@ -133,6 +133,14 @@
 * sse_kms_master_key_id = "aws/s3" # or your CMK ID
 * ```
 *
+* To reduce KMS request costs with SSE-KMS, enable an S3 Bucket Key.
+* This can only be set together with `sse_kms_master_key_id`.
+*
+* ```hcl
+* sse_kms_master_key_id  = "aws/s3" # or your CMK ID
+* sse_bucket_key_enabled = true
+* ```
+*
 * If you want to disable server side encryption, set disable_sse as `true`.
 *
 * ```hcl

--- a/aws/private-s3-bucket/variables.tf
+++ b/aws/private-s3-bucket/variables.tf
@@ -108,6 +108,17 @@ variable "sse_kms_master_key_id" {
   default     = null
 }
 
+variable "sse_bucket_key_enabled" {
+  type        = bool
+  description = "Whether to use an Amazon S3 Bucket Key for SSE-KMS. Reduces KMS request costs. Can only be set when sse_kms_master_key_id is set."
+  default     = null
+
+  validation {
+    condition     = var.sse_bucket_key_enabled == null || var.sse_kms_master_key_id != null
+    error_message = "'sse_bucket_key_enabled' can only be set when 'sse_kms_master_key_id' is set."
+  }
+}
+
 variable "cors_rule" {
   type = list(object({
     allowed_headers = list(string)


### PR DESCRIPTION
## What

Add a `sse_bucket_key_enabled` variable to the `private-s3-bucket` module so callers can enable an [S3 Bucket Key](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html) for SSE-KMS.

## Why

Previously, enabling a Bucket Key required dropping out of the module: setting `disable_sse = true` and hand-writing an `aws_s3_bucket_server_side_encryption_configuration` resource. This change lets the module handle it directly, which also reduces KMS request costs for SSE-KMS buckets.

`sse_bucket_key_enabled` can only be set together with `sse_kms_master_key_id` (guarded by a variable validation).

```hcl
module "example_bucket" {
  source = "github.com/elastic-infra/terraform-modules//aws/private-s3-bucket?ref=vX.X.X"

  bucket_name            = "example"
  sse_kms_master_key_id  = aws_kms_key.s3.arn
  sse_bucket_key_enabled = true
}
```